### PR TITLE
(#6) Update and add examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
 language: haskell
 notifications:
   email: false
+
+before_script:
+  # Set up a cabal sandbox for the examples that will reference the locally
+  # cloned version of scalpel.
+  - cd examples
+  - cabal sandbox init
+  - cabal sandbox add-source ../
+  - cd ..
+
+script:
+  # Run tests for the main library.
+  - cabal configure --enable-tests && cabal build && cabal test
+
+  # Ensure that the examples still compile.
+  - cd examples && cabal configure --enable-tests && cabal build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ script:
   - cabal configure --enable-tests && cabal build && cabal test
 
   # Ensure that the examples still compile.
-  - cd examples && cabal configure --enable-tests && cabal build
+  - cd examples
+  - cabal configure && cabal install --only-dependencies && cabal build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ script:
 
   # Ensure that the examples still compile.
   - cd examples
-  - cabal configure && cabal install --only-dependencies && cabal build
+  - cabal install --only-dependencies && cabal configure && cabal build

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ the given selector, while the plural variants match every instance.
 Example
 -------
 
+Complete examples can be found in the
+[examples](https://github.com/fimad/scalpel/examples) folder in the scalpel git
+repository.
+
 The following is an example that demonstrates most of the features provided by
 this library. Supposed you have the following hypothetical HTML located at
 `"http://example.com/article.html"` and you would like to extract a list of all
@@ -79,6 +83,7 @@ the web page, and extract all of the comments into a list:
     data Comment
         = TextComment Author String
         | ImageComment Author URL
+        deriving (Show, Eq)
 
     allComments :: IO (Maybe [Comment])
     allComments = scrapeURL "http://example.com/article.html" comments

--- a/examples/example-from-documentation/Main.hs
+++ b/examples/example-from-documentation/Main.hs
@@ -1,0 +1,51 @@
+import Text.HTML.Scalpel
+import Control.Applicative
+
+
+exampleHtml :: String
+exampleHtml = "<html>\
+\    <body>\
+\        <div class='comments'>\
+\            <div class='comment container'>\
+\                <span class='comment author'>Sally</span>\
+\                <div class='comment text'>Woo hoo!</div>\
+\            </div>\
+\            <div class='comment container'>\
+\                <span class='comment author'>Bill</span>\
+\                <img class='comment image' src='http://example.com/cat.gif' />\
+\            </div>\
+\            <div class='comment container'>\
+\                <span class='comment author'>Susan</span>\
+\                <div class='comment text'>WTF!?!</div>\
+\            </div>\
+\        </div>\
+\    </body>\
+\</html>"
+
+type Author = String
+
+data Comment
+    = TextComment Author String
+    | ImageComment Author URL
+    deriving (Show, Eq)
+
+main :: IO ()
+main = print $ scrapeStringLike exampleHtml comments
+    where
+    comments :: Scraper String [Comment]
+    comments = chroots ("div" @: [hasClass "container"]) comment
+
+    comment :: Scraper String Comment
+    comment = textComment <|> imageComment
+
+    textComment :: Scraper String Comment
+    textComment = do
+        author      <- text $ "span" @: [hasClass "author"]
+        commentText <- text $ "div"  @: [hasClass "text"]
+        return $ TextComment author commentText
+
+    imageComment :: Scraper String Comment
+    imageComment = do
+        author   <- text       $ "span" @: [hasClass "author"]
+        imageURL <- attr "src" $ "img"  @: [hasClass "image"]
+        return $ ImageComment author imageURL

--- a/examples/list-all-images/Main.hs
+++ b/examples/list-all-images/Main.hs
@@ -1,0 +1,18 @@
+import System.Environment
+import Text.HTML.Scalpel
+
+
+main :: IO ()
+main = getArgs >>= handleArgs
+
+handleArgs :: [String] -> IO ()
+handleArgs [url] = listUrlsForSite url
+handleArgs _     = putStrLn "usage: list-all-images URL"
+
+listUrlsForSite :: URL -> IO ()
+listUrlsForSite url = do
+    images <- scrapeURL url (attrs "src" "img")
+    maybe printError printImages images
+    where
+        printError = putStrLn "ERROR: Could not scrape the URL!"
+        printImages = mapM_ putStrLn

--- a/examples/scalpel-examples.cabal
+++ b/examples/scalpel-examples.cabal
@@ -1,0 +1,28 @@
+name:                scalpel-examples
+version:             0.1.0
+synopsis:            An example of how to use scalpel.
+description:         An example of how to use scalpel.
+homepage:            https://github.com/fimad/scalpel
+license:             Apache-2.0
+license-file:        ../LICENSE
+author:              Will Coster
+maintainer:          willcoster@gmail.com
+category:            Web
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable example-from-documentation
+  default-language: Haskell2010
+  main-is:          example-from-documentation/Main.hs
+  build-depends:
+          base          >= 4.6 && < 5
+      ,   scalpel       >= 0.2.0
+  ghc-options: -W
+
+executable list-all-images
+  default-language: Haskell2010
+  main-is:          list-all-images/Main.hs
+  build-depends:
+          base          >= 4.6 && < 5
+      ,   scalpel       >= 0.2.0
+  ghc-options: -W

--- a/src/Text/HTML/Scalpel.hs
+++ b/src/Text/HTML/Scalpel.hs
@@ -71,6 +71,7 @@
 -- > data Comment
 -- >     = TextComment Author String
 -- >     | ImageComment Author URL
+-- >     deriving (Show, Eq)
 -- >
 -- > allComments :: IO (Maybe [Comment])
 -- > allComments = scrapeURL "http://example.com/article.html" comments
@@ -92,6 +93,10 @@
 -- >            author   <- text       $ "span" @: [hasClass "author"]
 -- >            imageURL <- attr "src" $ "img"  @: [hasClass "image"]
 -- >            return $ ImageComment author imageURL
+--
+-- Complete examples can be found in the
+-- <https://github.com/fimad/scalpel/examples examples> folder in the scalpel
+-- git repository.
 module Text.HTML.Scalpel (
 -- * Selectors
     Selector


### PR DESCRIPTION
The examples in the documentation to deriving the Show type class,
without this GHCi will silently fail. Also add an examples directory
with full compilable examples.