### PR TITLE
More optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## HEAD
 
+- Added benchmarks and many optimizations.
+- The `select` method is removed from the public API.
+- Many methods now have a constraint that the string type parametrizing
+  TagSoup's tag type now must be order-able.
+
 ## 0.2.1.1
 
 - Cleanup stale instance references in documentation of TagName and

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -1,5 +1,6 @@
 import Text.HTML.Scalpel
 
+import Control.Monad (replicateM_)
 import Criterion.Main (bgroup, bench, defaultMain, nf)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -16,9 +17,18 @@ main = do
             ,   bench "1000" $ nf sumListTags nested1000
             ,   bench "2000" $ nf sumListTags nested2000
             ]
+        ,   bgroup "many-selects" [
+                bench "10"  $ nf (manySelects 10) nested1000
+            ,   bench "100" $ nf (manySelects 100) nested1000
+            ,   bench "1000" $ nf (manySelects 1000) nested1000
+            ]
         ]
 
 sumListTags :: T.Text -> Maybe Integer
 sumListTags testData = scrapeStringLike testData
                      $ (sum . map (const 1)) <$> texts "tag"
 
+manySelects :: Int -> T.Text -> Maybe ()
+manySelects i testData = scrapeStringLike testData
+                       $ replicateM_ i
+                       $ texts "tag"

--- a/src/Text/HTML/Scalpel.hs
+++ b/src/Text/HTML/Scalpel.hs
@@ -113,8 +113,6 @@ module Text.HTML.Scalpel (
 ,   (@=)
 ,   (@=~)
 ,   hasClass
--- ** Executing selectors
-,   select
 
 -- * Scrapers
 ,   Scraper
@@ -138,6 +136,5 @@ module Text.HTML.Scalpel (
 import Text.HTML.Scalpel.Internal.Scrape
 import Text.HTML.Scalpel.Internal.Scrape.StringLike
 import Text.HTML.Scalpel.Internal.Scrape.URL
-import Text.HTML.Scalpel.Internal.Select
 import Text.HTML.Scalpel.Internal.Select.Combinators
 import Text.HTML.Scalpel.Internal.Select.Types

--- a/src/Text/HTML/Scalpel/Internal/Scrape/StringLike.hs
+++ b/src/Text/HTML/Scalpel/Internal/Scrape/StringLike.hs
@@ -11,5 +11,6 @@ import qualified Text.StringLike as TagSoup
 
 -- | The 'scrapeStringLike' function parses a 'StringLike' value into a list of
 -- tags and executes a 'Scraper' on it.
-scrapeStringLike :: TagSoup.StringLike str => str -> Scraper str a -> Maybe a
+scrapeStringLike :: (Ord str, TagSoup.StringLike str)
+                 => str -> Scraper str a -> Maybe a
 scrapeStringLike html scraper = scrape scraper (TagSoup.parseTags html)

--- a/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
+++ b/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
@@ -7,7 +7,7 @@ module Text.HTML.Scalpel.Internal.Scrape.URL (
 
 import Text.HTML.Scalpel.Internal.Scrape
 
-import Control.Applicative
+import Control.Applicative ((<$>))
 
 import qualified Data.ByteString as BS
 import qualified Network.Curl as Curl
@@ -19,12 +19,13 @@ type URL = String
 
 -- | The 'scrapeURL' function downloads the contents of the given URL and
 -- executes a 'Scraper' on it.
-scrapeURL :: TagSoup.StringLike str => URL -> Scraper str a -> IO (Maybe a)
+scrapeURL :: (Ord str, TagSoup.StringLike str)
+          => URL -> Scraper str a -> IO (Maybe a)
 scrapeURL = scrapeURLWithOpts [Curl.CurlFollowLocation True]
 
 -- | The 'scrapeURLWithOpts' function take a list of curl options and downloads
 -- the contents of the given URL and executes a 'Scraper' on it.
-scrapeURLWithOpts :: TagSoup.StringLike str
+scrapeURLWithOpts :: (Ord str, TagSoup.StringLike str)
                   => [Curl.CurlOption] -> URL -> Scraper str a -> IO (Maybe a)
 scrapeURLWithOpts options url scraper = do
     maybeTags <- downloadAsTags url

--- a/src/Text/HTML/Scalpel/Internal/Select.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select.hs
@@ -3,7 +3,11 @@
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Text.HTML.Scalpel.Internal.Select (
-    select
+    CloseOffset
+
+,   select
+,   select_
+,   tagWithOffset
 ) where
 
 import Text.HTML.Scalpel.Internal.Select.Types
@@ -25,9 +29,18 @@ type CloseOffset = Maybe Int
 -- 'TagSoup.Tag's and returns a list of every subsequence of the given list of
 -- Tags that matches the given selector.
 select :: (Ord str, TagSoup.StringLike str, Selectable s)
-       => s -> [TagSoup.Tag str] -> [[TagSoup.Tag str]]
-select s = map (map fst) . selectNodes nodes . tagWithOffset
+       => s
+       -> [(TagSoup.Tag str, CloseOffset)]
+       -> [[(TagSoup.Tag str, CloseOffset)]]
+select s = selectNodes nodes
     where (MkSelector nodes) = toSelector s
+
+-- | Like 'select' but strips the 'CloseOffset' from the result.
+select_ :: (Ord str, TagSoup.StringLike str, Selectable s)
+       => s
+       -> [(TagSoup.Tag str, CloseOffset)]
+       -> [[TagSoup.Tag str]]
+select_ s = map (map fst) . select s
 
 -- | Annotate each tag with the offset to the corresponding closing tag. This
 -- annotating is done in O(n * log(n)).

--- a/src/Text/HTML/Scalpel/Internal/Select/Types.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Types.hs
@@ -42,7 +42,8 @@ class TagName t where
 -- returns a 'Bool' indicating if the given attribute matches a predicate.
 data AttributePredicate
         = MkAttributePredicate
-                (TagSoup.StringLike str => TagSoup.Attribute str -> Bool)
+                (forall str. TagSoup.StringLike str => TagSoup.Attribute str
+                                                    -> Bool)
 
 checkPred :: TagSoup.StringLike str
           => AttributePredicate -> TagSoup.Attribute str -> Bool


### PR DESCRIPTION
Only compute closing tag offsets once per scraper evaluation instead of once per select evaluation.