### PR TITLE
(closes #11) Add scrapeUrlWithConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - The `select` method is removed from the public API.
 - Many methods now have a constraint that the string type parametrizing
   TagSoup's tag type now must be order-able.
+- Added `scrapeUrlWithConfig` that will hopefully put an end to multiplying
+  `scrapeUrlWith*` methods.
+- The default behaviour of the `scrapeUrl*` methods is to attempt to infer the
+  character encoding from the `Content-Type` header.
 
 ## 0.2.1.1
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Example
 -------
 
 Complete examples can be found in the
-[examples](https://github.com/fimad/scalpel/examples) folder in the scalpel git
-repository.
+[examples](https://github.com/fimad/scalpel/tree/master/examples) folder in the
+scalpel git repository.
 
 The following is an example that demonstrates most of the features provided by
 this library. Supposed you have the following hypothetical HTML located at

--- a/scalpel.cabal
+++ b/scalpel.cabal
@@ -49,6 +49,7 @@ library
       ,   bytestring
       ,   containers
       ,   curl          >= 1.3.4
+      ,   data-default
       ,   regex-base
       ,   regex-tdfa
       ,   tagsoup       >= 0.12.2

--- a/src/Text/HTML/Scalpel.hs
+++ b/src/Text/HTML/Scalpel.hs
@@ -95,8 +95,8 @@
 -- >            return $ ImageComment author imageURL
 --
 -- Complete examples can be found in the
--- <https://github.com/fimad/scalpel/examples examples> folder in the scalpel
--- git repository.
+-- <https://github.com/fimad/scalpel/tree/master/examples examples> folder in
+-- the scalpel git repository.
 module Text.HTML.Scalpel (
 -- * Selectors
     Selector
@@ -131,6 +131,12 @@ module Text.HTML.Scalpel (
 ,   URL
 ,   scrapeURL
 ,   scrapeURLWithOpts
+,   scrapeURLWithConfig
+,   Config (..)
+,   Decoder
+,   defaultDecoder
+,   utf8Decoder
+,   iso88591Decoder
 ) where
 
 import Text.HTML.Scalpel.Internal.Scrape

--- a/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
+++ b/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
@@ -1,21 +1,54 @@
 {-# OPTIONS_HADDOCK hide #-}
 module Text.HTML.Scalpel.Internal.Scrape.URL (
     URL
+,   Config (..)
+,   Decoder
+
+,   defaultDecoder
+,   utf8Decoder
+,   iso88591Decoder
+
 ,   scrapeURL
 ,   scrapeURLWithOpts
+,   scrapeURLWithConfig
 ) where
 
 import Text.HTML.Scalpel.Internal.Scrape
 
 import Control.Applicative ((<$>))
+import Data.Char (toLower)
+import Data.Default (def)
+import Data.List (isInfixOf)
+import Data.Maybe (listToMaybe)
 
 import qualified Data.ByteString as BS
+import qualified Data.Default as Default
+import qualified Data.Text.Encoding as Text
 import qualified Network.Curl as Curl
 import qualified Text.HTML.TagSoup as TagSoup
 import qualified Text.StringLike as TagSoup
 
 
 type URL = String
+
+type CurlResponse = Curl.CurlResponse_ [(String, String)] BS.ByteString
+
+-- | A method that takes a HTTP response as raw bytes and returns the body as a
+-- string type.
+type Decoder str = Curl.CurlResponse_ [(String, String)] BS.ByteString -> str
+
+-- | A record type that determines how 'scrapeUrlWithConfig' interacts with the
+-- HTTP server and interprets the results.
+data Config str = Config {
+    curlOpts :: [Curl.CurlOption]
+,   decoder  :: Decoder str
+}
+
+instance TagSoup.StringLike str => Default.Default (Config str) where
+    def = Config {
+            curlOpts = [Curl.CurlFollowLocation True]
+        ,   decoder  = defaultDecoder
+        }
 
 -- | The 'scrapeURL' function downloads the contents of the given URL and
 -- executes a 'Scraper' on it.
@@ -27,22 +60,57 @@ scrapeURL = scrapeURLWithOpts [Curl.CurlFollowLocation True]
 -- the contents of the given URL and executes a 'Scraper' on it.
 scrapeURLWithOpts :: (Ord str, TagSoup.StringLike str)
                   => [Curl.CurlOption] -> URL -> Scraper str a -> IO (Maybe a)
-scrapeURLWithOpts options url scraper = do
-    maybeTags <- downloadAsTags url
+scrapeURLWithOpts options = scrapeURLWithConfig (def {curlOpts = options})
+
+-- | The 'scrapeURLWithConfig' function takes a 'Config' record type and
+-- downloads the contents of the given URL and executes a 'Scraper' on it.
+scrapeURLWithConfig :: (Ord str, TagSoup.StringLike str)
+                  => Config str -> URL -> Scraper str a -> IO (Maybe a)
+scrapeURLWithConfig config url scraper = do
+    maybeTags <- downloadAsTags (decoder config) url
     return (maybeTags >>= scrape scraper)
     where
-        downloadAsTags url = do
-            maybeBytes <- openURIWithOpts url options
-            return $ (TagSoup.parseTags . TagSoup.castString) <$> maybeBytes
+        downloadAsTags decoder url = do
+            maybeBytes <- openURIWithOpts url (curlOpts config)
+            return $ TagSoup.parseTags . decoder <$> maybeBytes
 
-openURIWithOpts :: URL -> [Curl.CurlOption] -> IO (Maybe BS.ByteString)
+openURIWithOpts :: URL -> [Curl.CurlOption] -> IO (Maybe CurlResponse)
 openURIWithOpts url opts = do
     resp <- curlGetResponse_ url opts
     return $ if Curl.respCurlCode resp /= Curl.CurlOK
         then Nothing
-        else Just $ Curl.respBody resp
+        else Just resp
 
 curlGetResponse_ :: URL
                  -> [Curl.CurlOption]
                  -> IO (Curl.CurlResponse_ [(String, String)] BS.ByteString)
 curlGetResponse_ = Curl.curlGetResponse_
+
+-- | The default response decoder. This decoder attempts to infer the character
+-- set of the HTTP response body from the `Content-Type` header. If this header
+-- is not present, then the character set is assumed to be `ISO-8859-1`.
+defaultDecoder :: TagSoup.StringLike str => Decoder str
+defaultDecoder response = TagSoup.castString
+                        $ choosenDecoder body
+    where
+        body        = Curl.respBody response
+        headers     = Curl.respHeaders response
+        contentType = listToMaybe
+                    $ map (map toLower . snd)
+                    $ take 1
+                    $ dropWhile ((/= "content-type") . map toLower . fst)
+                                headers
+
+        isType t | Just ct <- contentType = ("charset=" ++ t) `isInfixOf` ct
+                 | otherwise              = False
+
+        choosenDecoder | isType "utf-8" = Text.decodeUtf8
+                       | otherwise      = Text.decodeLatin1
+
+-- | A decoder that will always decode using `UTF-8`.
+utf8Decoder ::  TagSoup.StringLike str => Decoder str
+utf8Decoder = TagSoup.castString . Text.decodeUtf8 . Curl.respBody
+
+-- | A decoder that will always decode using `ISO-8859-1`.
+iso88591Decoder ::  TagSoup.StringLike str => Decoder str
+iso88591Decoder = TagSoup.castString . Text.decodeLatin1 . Curl.respBody


### PR DESCRIPTION
Adds a new more extensible method for scraping URLs. This function
takes a record type that can be extended in the future to further
modify the behavior of scraping URLs.

Besides the list of curl options, a new decoder option is added. The
decoder is a function that takes a curl response and turns it into a
string-like type. The default decoder attempts to infer the correct
encoding from the Content-Type header. If no character set is given
then it assumes ISO-8859-1.

There are also decoders that force UTF-8 or ISO-8859-1 for use with
websites that do a poor job of declaring their character sets.