### PR TITLE
(#19) Make tag matching case insensitive

### DIFF
--- a/src/Text/HTML/Scalpel/Internal/Scrape.hs
+++ b/src/Text/HTML/Scalpel/Internal/Scrape.hs
@@ -59,7 +59,7 @@ instance MonadPlus (Scraper str) where
 -- 'TagSoup.Tag's and produces an optional value.
 scrape :: (Ord str, TagSoup.StringLike str)
        => Scraper str a -> [TagSoup.Tag str] -> Maybe a
-scrape s = scrapeOffsets s . tagWithOffset
+scrape s = scrapeOffsets s . tagWithOffset . TagSoup.canonicalizeTags
 
 -- | The 'chroot' function takes a selector and an inner scraper and executes
 -- the inner scraper as if it were scraping a document that consists solely of

--- a/src/Text/HTML/Scalpel/Internal/Select/Types.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Types.hs
@@ -14,6 +14,8 @@ module Text.HTML.Scalpel.Internal.Select.Types (
 ,   SelectNode (..)
 ) where
 
+import Data.Char (toLower)
+
 import qualified Text.HTML.TagSoup as TagSoup
 import qualified Text.StringLike as TagSoup
 
@@ -68,7 +70,7 @@ instance Selectable Selector where
     toSelector = id
 
 instance Selectable String where
-    toSelector node = MkSelector [SelectNode node []]
+    toSelector node = MkSelector [SelectNode (map toLower node) []]
 
 instance Selectable Any where
     toSelector = const (MkSelector [SelectAny []])
@@ -77,10 +79,10 @@ instance AttributeName Any where
     matchKey = const . const True
 
 instance AttributeName String where
-    matchKey = (==) . TagSoup.fromString
+    matchKey = (==) . TagSoup.fromString . map toLower
 
 instance TagName Any where
     toSelectNode = const SelectAny
 
 instance TagName String where
-    toSelectNode = SelectNode . TagSoup.fromString
+    toSelectNode = SelectNode . TagSoup.fromString . map toLower

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -158,6 +158,26 @@ scrapeTests = "scrapeTests" ~: TestList [
     ,   scrapeTest "<img src='foobar'>" (Just "foobar") (attr "src" "img")
 
     ,   scrapeTest "<img src='foobar' />" (Just "foobar") (attr "src" "img")
+
+    ,   scrapeTest
+            "<a>foo</a><A>bar</A>"
+            (Just ["foo", "bar"])
+            (texts "a")
+
+    ,   scrapeTest
+            "<a>foo</a><A>bar</A>"
+            (Just ["foo", "bar"])
+            (texts "A")
+
+    ,   scrapeTest
+            "<a B=C>foo</a>"
+            (Just ["foo"])
+            (texts $ "A" @: ["b" @= "C"])
+
+    ,   scrapeTest
+            "<a B=C>foo</a>"
+            Nothing
+            (texts $ "A" @: ["b" @= "c"])
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test


### PR DESCRIPTION
Tags are now passed through TagSoup's canonicalize which converts all
tag and attribute names to lower case. Similarly all tag names and
attribute names used in scrapers are lower cased prior to being
evaluated.