### PR TITLE
(#22) Allows construction of arbitrary predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## HEAD
 
-- Add the `innerHTML` and `innerHTMLs` scraper.
+- Added the `innerHTML` and `innerHTMLs` scraper.
+- Added the `match` function which allows for the creation of arbitrary
+  attribute predicates.
 
 ## 0.3.0.1
 

--- a/src/Text/HTML/Scalpel.hs
+++ b/src/Text/HTML/Scalpel.hs
@@ -113,6 +113,7 @@ module Text.HTML.Scalpel (
 ,   (@=)
 ,   (@=~)
 ,   hasClass
+,   match
 
 -- * Scrapers
 ,   Scraper

--- a/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
@@ -8,6 +8,7 @@ module Text.HTML.Scalpel.Internal.Select.Combinators (
 ,   (@=)
 ,   (@=~)
 ,   hasClass
+,   match
 ) where
 
 import Text.HTML.Scalpel.Internal.Select.Types
@@ -65,3 +66,11 @@ hasClass clazz = MkAttributePredicate hasClass'
             where textClass   = TagSoup.castString clazz
                   textClasses = TagSoup.castString classes
                   classList   = T.split (== ' ') textClasses
+
+-- | The 'match' function allows for the creation of arbitrary
+-- 'AttributePredicate's. The argument is a function that takes the attribute
+-- key followed by the attribute value and returns a boolean indicating if the
+-- attribute satisfies the predicate.
+match :: (String -> String -> Bool) -> AttributePredicate
+match f = MkAttributePredicate $ \(attrKey, attrValue) ->
+              f (TagSoup.toString attrKey) (TagSoup.toString attrValue)

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -102,6 +102,11 @@ scrapeTests = "scrapeTests" ~: TestList [
             (htmls (Any @: [Any @= "value"]))
 
     ,   scrapeTest
+            "<a foo=\"bar\">1</a><a foo=\"foo\">2</a><a bar=\"bar\">3</a>"
+            (Just ["<a foo=\"foo\">2</a>", "<a bar=\"bar\">3</a>"])
+            (htmls (Any @: [match (==)]))
+
+    ,   scrapeTest
             "<a>foo</a>"
             (Just "foo")
             (text "a")


### PR DESCRIPTION
The `match` function is exposed which can be used to create
AttributePredicate values from functions that take a string valued
attribute key and attribute value and return a boolean.