### PR TITLE
failed to build with ghc-8.0.1

### DIFF
--- a/src/Text/HTML/Scalpel/Internal/Select.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_HADDOCK hide #-}


### PR DESCRIPTION
scalpel-0.3.0.1 couldn't compile with ghc-8.0.1.

The error message was something like:

```
src/Text/HTML/Scalpel/Internal/Select.hs:78:28: error:
    • Couldn't match type ‘forall a. Maybe a’ with ‘CloseOffset’
      Expected type: (TagSoup.Tag str, Int)
                     -> ((TagSoup.Tag str, CloseOffset), Int)
        Actual type: (TagSoup.Tag str, Int)
                     -> ((TagSoup.Tag str, forall a. Maybe a), Int)
    • In the first argument of ‘map’, namely ‘(first (, Nothing))’
      In the expression: map (first (, Nothing))
      In the expression:
        map (first (, Nothing)) $ concat $ Map.elems state
```


When I remove `ImpredicativeTypes` extension, it compiles fine. Maybe it's because of the [Impredicative types brokenness](https://ghc.haskell.org/trac/ghc/wiki/Migration/8.0#Impredicativetypesbrokenness).

I've never used this extension. Is it really necessary?
