### PR TITLE
(#28) Fixes bug with nested selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add the `chroot` tricks (#23 and #25) to README.md and added examples.
 - Fix backtracking that occurs when using `guard` and `chroot`.
+- Fix bug where the same tag may appear in the result set multiple times.
+- Performance optimizations when using the (//) operator.
 
 ## 0.3.1
 

--- a/scalpel.cabal
+++ b/scalpel.cabal
@@ -47,7 +47,6 @@ library
       ,   containers
       ,   curl          >= 1.3.4
       ,   data-default
-      ,   IntervalMap
       ,   regex-base
       ,   regex-tdfa
       ,   tagsoup       >= 0.12.2

--- a/scalpel.cabal
+++ b/scalpel.cabal
@@ -47,10 +47,12 @@ library
       ,   containers
       ,   curl          >= 1.3.4
       ,   data-default
+      ,   IntervalMap
       ,   regex-base
       ,   regex-tdfa
       ,   tagsoup       >= 0.12.2
       ,   text
+      ,   vector
   default-extensions:
           ParallelListComp
       ,   PatternGuards
@@ -79,8 +81,9 @@ benchmark bench
   hs-source-dirs:   benchmarks
   main-is:          Main.hs
   build-depends:
-      base               >=4.7 && <5
-    , criterion          >=1.1
-    , scalpel
-    , text
+         base           >=4.7 && <5
+      ,  criterion      >=1.1
+      ,  scalpel
+      ,  tagsoup
+      ,  text
   ghc-options: -Wall

--- a/src/Text/HTML/Scalpel/Internal/Scrape/StringLike.hs
+++ b/src/Text/HTML/Scalpel/Internal/Scrape/StringLike.hs
@@ -13,4 +13,5 @@ import qualified Text.StringLike as TagSoup
 -- tags and executes a 'Scraper' on it.
 scrapeStringLike :: (Ord str, TagSoup.StringLike str)
                  => str -> Scraper str a -> Maybe a
-scrapeStringLike html scraper = scrape scraper (TagSoup.parseTags html)
+scrapeStringLike html scraper
+    = scrape scraper (TagSoup.parseTagsOptions TagSoup.parseOptionsFast html)

--- a/src/Text/HTML/Scalpel/Internal/Select/Types.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Types.hs
@@ -18,6 +18,7 @@ import Data.Char (toLower)
 
 import qualified Text.HTML.TagSoup as TagSoup
 import qualified Text.StringLike as TagSoup
+import qualified Data.Text as T
 
 
 -- | The 'Selectable' class defines a class of types that are capable of being
@@ -63,14 +64,14 @@ data Any = Any
 -- selection, all of the inner tags, and the corresponding closing tag.
 newtype Selector = MkSelector [SelectNode]
 
-data SelectNode = SelectNode String [AttributePredicate]
+data SelectNode = SelectNode !T.Text [AttributePredicate]
                 | SelectAny [AttributePredicate]
 
 instance Selectable Selector where
     toSelector = id
 
 instance Selectable String where
-    toSelector node = MkSelector [SelectNode (map toLower node) []]
+    toSelector node = MkSelector [SelectNode (T.pack $ map toLower node) []]
 
 instance Selectable Any where
     toSelector = const (MkSelector [SelectAny []])

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -50,7 +50,7 @@ scrapeTests = "scrapeTests" ~: TestList [
 
     ,   scrapeTest
             "<a>foo"
-            (Just ["<a></a>"])
+            (Just ["<a>"])
             (htmls ("a" @: []))
 
     ,   scrapeTest
@@ -158,9 +158,15 @@ scrapeTests = "scrapeTests" ~: TestList [
             (Just "bar")
             (text ("a" // "d") <|> text ("a" // "c"))
 
-    ,   scrapeTest "<img src='foobar'>" (Just "foobar") (attr "src" "img")
+    ,   scrapeTest
+            "<img src='foobar'>"
+            (Just "foobar")
+            (attr "src" "img")
 
-    ,   scrapeTest "<img src='foobar' />" (Just "foobar") (attr "src" "img")
+    ,   scrapeTest
+            "<img src='foobar' />"
+            (Just "foobar")
+            (attr "src" "img")
 
     ,   scrapeTest
             "<a>foo</a><A>bar</A>"
@@ -234,6 +240,21 @@ scrapeTests = "scrapeTests" ~: TestList [
                 t <- text Any
                 guard ("b" `isInfixOf` t)
                 html Any)
+
+    ,   scrapeTest
+            "<div id=\"outer\"><div id=\"inner\">inner text</div></div>"
+            (Just ["inner"])
+            (attrs "id" ("div" // "div"))
+
+    ,   scrapeTest
+            "<div id=\"a\"><div id=\"b\"><div id=\"c\"></div></div></div>"
+            (Just ["b", "c"])
+            (attrs "id" ("div" // "div"))
+
+    ,   scrapeTest
+            "<a>1<b>2<c>3</c>4</b>5</a>"
+            (Just "12345")
+            (text Any)
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test


### PR DESCRIPTION
This commit fixes two bugs that occur when using the `//` operator:

  1) The first is that using any of the pluralized scrapers with a
     selector created from one or more `//` operators will potentially
     return duplicate tags. This occurs if there are multiple ways in
     which a given tag may satisfy the selector.

  2) The `//` operator does not force a decent from the current
     context. For example, if one attempts to match a nested div
     `<div id=a><div id=b></div></div>` with the selector
     `"div" // "div"` the outer div will be matched.

In order to fix this bug without regressing on performance the entire
selection engine had to be re-written. The engine now features linear
time matching for tags as opposed to the probably exponential prior
implementation.