### PR TITLE
Improve scalpel usage with OverloadedStrings enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,31 @@ Applicative, Alternative, etc.).
 This section gives examples of common tricks for building up more complex
 behavior from the simple primitives provided by this library.
 
+### OverloadedStrings
+
+`Selector`, `TagName` and `AttributeName` are all `IsString` instances, and
+thus it is convenient to use scalpel with `OverloadedStrings` enabled. If not
+using `OverloadedStrings`, all tag names must be wrapped with `tagSelector`.
+
+### Matching Wildcards
+
+Scalpel has 3 different wildcard values each corresponding to a distinct use case.
+
+- `anySelector` is used to match all tags:
+
+    `textOfAllTags = texts anySelector`
+
+- `AnyTag` is used when matching all tags with some attribute constraint. For
+  example, to match all tags with the attribute `class` equal to `"button"`:
+
+    `textOfTagsWithClassButton = texts $ AnyTag @: [hasClass "button"]`
+
+- `AnyAttribute` is used when matching tags with some arbitrary attribute equal
+   to a particular value. For example, to match all tags with some attribute
+   equal to `"button"`:
+
+    `textOfTagsWithAnAttributeWhoseValueIsButton = texts $ AnyTag @: [AnyAttribute @= "button"]`
+
 ### Complex Predicates
 
 It is possible to run into scenarios where the name and attributes of a tag are
@@ -206,15 +231,3 @@ altTextAndImages =
 For the full source of this example, see
 [generalized-repetition](https://github.com/fimad/scalpel/tree/master/examples/generalized-repetition/)
 in the examples directory.
-
-### Matching wildcards
-
- - `anySelector` will match all tags
- - `AnyTag` will match all tag names
- - `AnyAttribute` will match all tag attributes
-
-### OverloadedStrings
-
-`Selector`, `TagName` and `AttributeName` are all `IsString` instances, and
-thus it is convenient to use scalpel with `OverloadedStrings` enabled. If not
-using `OverloadedStrings`, all tag names must be wrapped with `tagSelector`.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ not sufficient to isolate interesting tags and properties of child tags need to
 be considered.
 
 In these cases the `guard` function of the `Alternative` type class can be
-combined with `chroot` and `Any` to implement predicates of arbitrary
+combined with `chroot` and `anySelector` to implement predicates of arbitrary
 complexity.
 
 Building off the above example, consider a use case where we would like find the
@@ -139,8 +139,8 @@ The strategy will be the following:
 1. Isolate the comment div using `chroot`.
 
 2. Then within the context of that div the textual contents can be retrieved
-   with `text Any`. This works because the first tag within the current context
-   is the div tag selected by chroot, and the `Any` selector will match the
+   with `text anySelector`. This works because the first tag within the current context
+   is the div tag selected by chroot, and the `anySelector` selector will match the
    first tag within the current context.
 
 3. Then the predicate that `"cat"` appear in the text of the comment will be
@@ -155,12 +155,12 @@ catComment =
     -- 1. First narrow the current context to the div containing the comment's
     --    textual content.
     chroot ("div" @: [hasClass "comment", hasClass "text"]) $ do
-        -- 2. Any can be used to access the root tag of the current context.
-        contents <- text Any
+        -- 2. anySelector can be used to access the root tag of the current context.
+        contents <- text anySelector
         -- 3. Skip comment divs that do not contain "cat".
         guard ("cat" `isInfixOf` contents)
         -- 4. Generate the desired value.
-        html Any
+        html anySelector
 ```
 
 For the full source of this example, see
@@ -175,7 +175,7 @@ selector. For more complex scraping tasks it will at times be desirable to be
 able to extract multiple values from the same tag.
 
 Like the previous example, the trick here is to use a combination of the
-`chroots` function and the `Any` selector.
+`chroots` function and the `anySelector` selector.
 
 Consider an extension to the original example where image comments may contain
 some alt text and the desire is to return a tuple of the alt text and the URLs
@@ -185,7 +185,7 @@ The strategy will be the following:
 
 1. to isolate each img tag using `chroots`.
 
-2. Then within the context of each img tag, use the `Any` selector to extract
+2. Then within the context of each img tag, use the `anySelector` selector to extract
    the alt and src attributes from the current tag.
 
 3. Create and return a tuple of the extracted attributes.
@@ -195,10 +195,10 @@ altTextAndImages :: Scraper String [(String, URL)]
 altTextAndImages =
     -- 1. First narrow the current context to each img tag.
     chroots "img" $ do
-        -- 2. Use Any to access all the relevant content from the the currently
+        -- 2. Use anySelector to access all the relevant content from the the currently
         -- selected img tag.
-        altText <- attr "alt" Any
-        srcUrl  <- attr "src" Any
+        altText <- attr "alt" anySelector
+        srcUrl  <- attr "src" anySelector
         -- 3. Combine the retrieved content into the desired final result.
         return (altText, srcUrl)
 ```
@@ -206,3 +206,15 @@ altTextAndImages =
 For the full source of this example, see
 [generalized-repetition](https://github.com/fimad/scalpel/tree/master/examples/generalized-repetition/)
 in the examples directory.
+
+### Matching wildcards
+
+ - `anySelector` will match all tags
+ - `AnyTag` will match all tag names
+ - `AnyAttribute` will match all tag attributes
+
+### OverloadedStrings
+
+`Selector`, `TagName` and `AttributeName` are all `IsString` instances, and
+thus it is convenient to use scalpel with `OverloadedStrings` enabled. If not
+using `OverloadedStrings`, all tag names must be wrapped with `tagSelector`.

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 import Text.HTML.Scalpel
 
 import Control.Applicative ((<$>))
@@ -51,5 +53,5 @@ manySelects i testData = flip scrape testData
 manySelectNodes :: Int -> [TagSoup.Tag T.Text] -> Maybe T.Text
 manySelectNodes i testData = flip scrape testData
                            $ text
-                           $ foldr' (//) (toSelector "tag")
-                           $ replicate (i - 1) (toSelector "tag")
+                           $ foldr' (//) (tagSelector "tag")
+                           $ replicate (i - 1) (tagSelector "tag")

--- a/examples/complex-predicates/Main.hs
+++ b/examples/complex-predicates/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 import Text.HTML.Scalpel
 import Control.Applicative
 import Control.Monad
@@ -37,8 +39,8 @@ catComment =
     --    textual content.
     chroot ("div" @: [hasClass "comment", hasClass "text"]) $ do
         -- 2. Any can be used to access the root tag of the current context.
-        contents <- text Any
+        contents <- text anySelector
         -- 3. Skip comment divs that do not contain "cat".
         guard ("cat" `isInfixOf` contents)
         -- 4. Generate the desired value.
-        html Any
+        html anySelector

--- a/examples/example-from-documentation/Main.hs
+++ b/examples/example-from-documentation/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 import Text.HTML.Scalpel
 import Control.Applicative
 

--- a/examples/generalized-repetition/Main.hs
+++ b/examples/generalized-repetition/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 import Text.HTML.Scalpel
 
 
@@ -36,7 +38,7 @@ altTextAndImages =
     chroots "img" $ do
         -- 2. Use Any to access all the relevant content from the the currently
         -- selected img tag.
-        altText <- attr "alt" Any
-        srcUrl  <- attr "src" Any
+        altText <- attr "alt" anySelector
+        srcUrl  <- attr "src" anySelector
         -- 3. Combine the retrieved content into the desired final result.
         return (altText, srcUrl)

--- a/examples/list-all-images/Main.hs
+++ b/examples/list-all-images/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 import System.Environment
 import Text.HTML.Scalpel
 

--- a/src/Text/HTML/Scalpel.hs
+++ b/src/Text/HTML/Scalpel.hs
@@ -103,6 +103,7 @@ module Text.HTML.Scalpel (
 ,   AttributePredicate
 ,   AttributeName (..)
 ,   TagName (..)
+,   tagSelector
 -- ** Wildcards
 ,   anySelector
 -- ** Tag combinators

--- a/src/Text/HTML/Scalpel.hs
+++ b/src/Text/HTML/Scalpel.hs
@@ -100,12 +100,12 @@
 module Text.HTML.Scalpel (
 -- * Selectors
     Selector
-,   Selectable (..)
 ,   AttributePredicate
 ,   AttributeName
 ,   TagName
 -- ** Wildcards
 ,   Any (..)
+,   anySelector
 -- ** Tag combinators
 ,   (//)
 -- ** Attribute predicates

--- a/src/Text/HTML/Scalpel.hs
+++ b/src/Text/HTML/Scalpel.hs
@@ -101,10 +101,9 @@ module Text.HTML.Scalpel (
 -- * Selectors
     Selector
 ,   AttributePredicate
-,   AttributeName
-,   TagName
+,   AttributeName (..)
+,   TagName (..)
 -- ** Wildcards
-,   Any (..)
 ,   anySelector
 -- ** Tag combinators
 ,   (//)

--- a/src/Text/HTML/Scalpel/Internal/Scrape.hs
+++ b/src/Text/HTML/Scalpel/Internal/Scrape.hs
@@ -70,8 +70,8 @@ scrape s = scrapeTagSpec s . tagsToSpec . TagSoup.canonicalizeTags
 --
 -- This function will match only the first set of tags matching the selector, to
 -- match every set of tags, use 'chroots'.
-chroot :: (Ord str, TagSoup.StringLike str, Selectable s)
-       => s -> Scraper str a -> Scraper str a
+chroot :: (Ord str, TagSoup.StringLike str)
+       => Selector -> Scraper str a -> Scraper str a
 chroot selector inner = do
     maybeResult <- listToMaybe <$> chroots selector inner
     guard (isJust maybeResult)
@@ -81,8 +81,8 @@ chroot selector inner = do
 -- the inner scraper as if it were scraping a document that consists solely of
 -- the tags corresponding to the selector. The inner scraper is executed for
 -- each set of tags matching the given selector.
-chroots :: (Ord str, TagSoup.StringLike str, Selectable s)
-        => s -> Scraper str a -> Scraper str [a]
+chroots :: (Ord str, TagSoup.StringLike str)
+        => Selector -> Scraper str a -> Scraper str [a]
 chroots selector (MkScraper inner) = MkScraper
                                    $ return . mapMaybe inner . select selector
 
@@ -91,13 +91,13 @@ chroots selector (MkScraper inner) = MkScraper
 --
 -- This function will match only the first set of tags matching the selector, to
 -- match every set of tags, use 'texts'.
-text :: (Ord str, TagSoup.StringLike str, Selectable s) => s -> Scraper str str
+text :: (Ord str, TagSoup.StringLike str) => Selector -> Scraper str str
 text s = MkScraper $ withHead tagsToText . select s
 
 -- | The 'texts' function takes a selector and returns the inner text from every
 -- set of tags matching the given selector.
-texts :: (Ord str, TagSoup.StringLike str, Selectable s)
-      => s -> Scraper str [str]
+texts :: (Ord str, TagSoup.StringLike str)
+      => Selector -> Scraper str [str]
 texts s = MkScraper $ withAll tagsToText . select s
 
 -- | The 'html' function takes a selector and returns the html string from the
@@ -105,13 +105,13 @@ texts s = MkScraper $ withAll tagsToText . select s
 --
 -- This function will match only the first set of tags matching the selector, to
 -- match every set of tags, use 'htmls'.
-html :: (Ord str, TagSoup.StringLike str, Selectable s) => s -> Scraper str str
+html :: (Ord str, TagSoup.StringLike str) => Selector -> Scraper str str
 html s = MkScraper $ withHead tagsToHTML . select s
 
 -- | The 'htmls' function takes a selector and returns the html string from
 -- every set of tags matching the given selector.
-htmls :: (Ord str, TagSoup.StringLike str, Selectable s)
-      => s -> Scraper str [str]
+htmls :: (Ord str, TagSoup.StringLike str)
+      => Selector -> Scraper str [str]
 htmls s = MkScraper $ withAll tagsToHTML . select s
 
 -- | The 'innerHTML' function takes a selector and returns the inner html string
@@ -120,14 +120,14 @@ htmls s = MkScraper $ withAll tagsToHTML . select s
 --
 -- This function will match only the first set of tags matching the selector, to
 -- match every set of tags, use 'innerHTMLs'.
-innerHTML :: (Ord str, TagSoup.StringLike str, Selectable s)
-          => s -> Scraper str str
+innerHTML :: (Ord str, TagSoup.StringLike str)
+          => Selector -> Scraper str str
 innerHTML s = MkScraper $ withHead tagsToInnerHTML . select s
 
 -- | The 'innerHTMLs' function takes a selector and returns the inner html
 -- string from every set of tags matching the given selector.
-innerHTMLs :: (Ord str, TagSoup.StringLike str, Selectable s)
-           => s -> Scraper str [str]
+innerHTMLs :: (Ord str, TagSoup.StringLike str)
+           => Selector -> Scraper str [str]
 innerHTMLs s = MkScraper $ withAll tagsToInnerHTML . select s
 
 -- | The 'attr' function takes an attribute name and a selector and returns the
@@ -136,16 +136,16 @@ innerHTMLs s = MkScraper $ withAll tagsToInnerHTML . select s
 --
 -- This function will match only the opening tag matching the selector, to match
 -- every tag, use 'attrs'.
-attr :: (Ord str, Show str, TagSoup.StringLike str, Selectable s)
-     => String -> s -> Scraper str str
+attr :: (Ord str, Show str, TagSoup.StringLike str)
+     => String -> Selector -> Scraper str str
 attr name s = MkScraper
             $ join . withHead (tagsToAttr $ TagSoup.castString name) . select s
 
 -- | The 'attrs' function takes an attribute name and a selector and returns the
 -- value of the attribute of the given name for every opening tag that matches
 -- the given selector.
-attrs :: (Ord str, Show str, TagSoup.StringLike str, Selectable s)
-     => String -> s -> Scraper str [str]
+attrs :: (Ord str, Show str, TagSoup.StringLike str)
+     => String -> Selector -> Scraper str [str]
 attrs name s = MkScraper
              $ fmap catMaybes . withAll (tagsToAttr nameStr) . select s
     where nameStr = TagSoup.castString name

--- a/src/Text/HTML/Scalpel/Internal/Select.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select.hs
@@ -59,10 +59,10 @@ type TagSpec str = (TagVector str, TagForest)
 -- | The 'select' function takes a 'Selectable' value and a list of
 -- 'TagSoup.Tag's and returns a list of every subsequence of the given list of
 -- Tags that matches the given selector.
-select :: (Ord str, TagSoup.StringLike str, Selectable s)
-       => s -> TagSpec str -> [TagSpec str]
+select :: (Ord str, TagSoup.StringLike str)
+       => Selector -> TagSpec str -> [TagSpec str]
 select s = ($ []) . selectNodes nodes
-    where (MkSelector nodes) = toSelector s
+    where (MkSelector nodes) = s
 
 -- | Creates a TagSpec from a list of tags parsed by TagSoup.
 tagsToSpec :: forall str. (Ord str, TagSoup.StringLike str)

--- a/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
@@ -29,7 +29,7 @@ infixl 9 @:
 --
 -- If you are attempting to match a specific class of a tag with potentially
 -- multiple classes, you should use the 'hasClass' utility function.
-(@=) :: AttributeName key => key -> String -> AttributePredicate
+(@=) :: AttributeName -> String -> AttributePredicate
 (@=) key value = MkAttributePredicate $ \(attrKey, attrValue) ->
                                          matchKey key attrKey
                                       && TagSoup.fromString value == attrValue
@@ -38,8 +38,8 @@ infixl 6 @=
 -- | The '@=~' operator creates an 'AttributePredicate' that will match
 -- attributes with the given name and whose value matches the given regular
 -- expression.
-(@=~) :: (AttributeName key, RE.RegexLike re String)
-      => key -> re -> AttributePredicate
+(@=~) :: RE.RegexLike re String
+      => AttributeName -> re -> AttributePredicate
 (@=~) key re = MkAttributePredicate $ \(attrKey, attrValue) ->
        matchKey key attrKey
     && RE.matchTest re (TagSoup.toString attrValue)

--- a/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
@@ -48,10 +48,10 @@ infixl 6 @=~
 -- | The '//' operator creates an 'Selector' by nesting one 'Selector' in
 -- another. For example, @"div" // "a"@ will create a 'Selector' that matches
 -- anchor tags that are nested arbitrarily deep within a div tag.
-(//) :: (Selectable a, Selectable b) => a -> b -> Selector
+(//) :: Selector -> Selector -> Selector
 (//) a b = MkSelector (as ++ bs)
-    where (MkSelector as) = toSelector a
-          (MkSelector bs) = toSelector b
+    where (MkSelector as) = a
+          (MkSelector bs) = b
 infixl 5 //
 
 -- | The classes of a tag are defined in HTML as a space separated list given by

--- a/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
@@ -20,7 +20,7 @@ import qualified Text.StringLike as TagSoup
 
 -- | The '@:' operator creates a 'Selector' by combining a 'TagName' with a list
 -- of 'AttributePredicate's.
-(@:) :: TagName tag => tag -> [AttributePredicate] -> Selector
+(@:) :: TagName -> [AttributePredicate] -> Selector
 (@:) tag attrs = MkSelector [toSelectNode tag attrs]
 infixl 9 @:
 

--- a/src/Text/HTML/Scalpel/Internal/Select/Types.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Types.hs
@@ -4,28 +4,23 @@
 {-# OPTIONS_HADDOCK hide #-}
 module Text.HTML.Scalpel.Internal.Select.Types (
     Selector (..)
-,   Selectable (..)
 ,   AttributePredicate (..)
 ,   checkPred
 ,   Any (..)
 ,   AttributeName (..)
 ,   TagName (..)
-
 ,   SelectNode (..)
+,   tagSelector
+,   anySelector
 ) where
 
 import Data.Char (toLower)
+import Data.String (IsString, fromString)
 
 import qualified Text.HTML.TagSoup as TagSoup
 import qualified Text.StringLike as TagSoup
 import qualified Data.Text as T
 
-
--- | The 'Selectable' class defines a class of types that are capable of being
--- cast into a 'Selector' which in turns describes a section of an HTML DOM
--- tree.
-class Selectable s where
-    toSelector :: s -> Selector
 
 -- | The 'AttributeName' class defines a class of types that can be used when
 -- creating 'Selector's to specify the name of an attribute of a tag.  Currently
@@ -64,17 +59,27 @@ data Any = Any
 -- selection, all of the inner tags, and the corresponding closing tag.
 newtype Selector = MkSelector [SelectNode]
 
+tagSelector :: String -> Selector
+tagSelector tag = MkSelector [toSelectNode tag []]
+
+-- | Substitute for 'Any'.
+anySelector :: Selector
+anySelector = MkSelector [SelectAny []]
+
+instance IsString Selector where
+  fromString = tagSelector
+
 data SelectNode = SelectNode !T.Text [AttributePredicate]
                 | SelectAny [AttributePredicate]
 
-instance Selectable Selector where
-    toSelector = id
-
-instance Selectable String where
-    toSelector node = MkSelector [SelectNode (T.pack $ map toLower node) []]
-
-instance Selectable Any where
-    toSelector = const (MkSelector [SelectAny []])
+-- instance Selectable Selector where
+--     toSelector = id
+--
+-- instance Selectable String where
+--     toSelector node = MkSelector [SelectNode (T.pack $ map toLower node) []]
+--
+-- instance Selectable Any where
+--     toSelector = const (MkSelector [SelectAny []])
 
 instance AttributeName Any where
     matchKey = const . const True

--- a/src/Text/HTML/Scalpel/Internal/Select/Types.hs
+++ b/src/Text/HTML/Scalpel/Internal/Select/Types.hs
@@ -24,13 +24,8 @@ import qualified Text.StringLike as TagSoup
 import qualified Data.Text as T
 
 
--- | The 'AttributeName' class defines a class of types that can be used when
--- creating 'Selector's to specify the name of an attribute of a tag.  Currently
--- the only types of this class are 'String' for matching attributes exactly,
--- and 'Any' for matching attributes with any name.
--- class AttributeName k where
---     matchKey :: TagSoup.StringLike str => k -> str -> Bool
-
+-- | The 'AttributeName' type can be used when creating 'Selector's to specify
+-- the name of an attribute of a tag.
 data AttributeName = AnyAttribute | AttributeString String
 
 matchKey :: TagSoup.StringLike str => AttributeName -> str -> Bool
@@ -59,7 +54,7 @@ newtype Selector = MkSelector [SelectNode]
 tagSelector :: String -> Selector
 tagSelector tag = MkSelector [toSelectNode (TagString tag) []]
 
--- | Selector-specific substitute for 'Any'.
+-- | A selector which will match all tags
 anySelector :: Selector
 anySelector = MkSelector [SelectAny []]
 

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 module Main (main) where
 
 import Text.HTML.Scalpel
@@ -27,37 +28,37 @@ scrapeTests = "scrapeTests" ~: TestList [
         scrapeTest
             "<a>foo</a>"
             (Just ["<a>foo</a>"])
-            (htmls (("a" :: String) @: []))
+            (htmls ("a" @: []))
 
     ,   scrapeTest
             "<a>foo</a><a>bar</a>"
             (Just ["<a>foo</a>", "<a>bar</a>"])
-            (htmls (("a" :: String) @: []))
+            (htmls ("a" @: []))
 
-    -- ,   scrapeTest
-    --         "<b><a>foo</a></b>"
-    --         (Just ["<a>foo</a>"])
-    --         (htmls ("a" @: []))
+    ,   scrapeTest
+            "<b><a>foo</a></b>"
+            (Just ["<a>foo</a>"])
+            (htmls ("a" @: []))
 
-    -- ,   scrapeTest
-    --         "<a><a>foo</a></a>"
-    --         (Just ["<a><a>foo</a></a>", "<a>foo</a>"])
-    --         (htmls ("a" @: []))
+    ,   scrapeTest
+            "<a><a>foo</a></a>"
+            (Just ["<a><a>foo</a></a>", "<a>foo</a>"])
+            (htmls ("a" @: []))
 
-    -- ,   scrapeTest
-    --         "<a>foo</a>"
-    --         Nothing
-    --         (htmls ("b" @: []))
+    ,   scrapeTest
+            "<a>foo</a>"
+            Nothing
+            (htmls ("b" @: []))
 
-    -- ,   scrapeTest
-    --         "<a>foo"
-    --         (Just ["<a>"])
-    --         (htmls ("a" @: []))
+    ,   scrapeTest
+            "<a>foo"
+            (Just ["<a>"])
+            (htmls ("a" @: []))
 
-    -- ,   scrapeTest
-    --         "<a>foo</a><a key=\"value\">bar</a>"
-    --         (Just ["<a key=\"value\">bar</a>"])
-    --         (htmls ("a" @: ["key" @= "value"]))
+    ,   scrapeTest
+            "<a>foo</a><a key=\"value\">bar</a>"
+            (Just ["<a key=\"value\">bar</a>"])
+            (htmls ("a" @: ["key" @= "value"]))
 
     -- ,   scrapeTest
     --         "<a><b><c>foo</c></b></a>"

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -60,55 +60,55 @@ scrapeTests = "scrapeTests" ~: TestList [
             (Just ["<a key=\"value\">bar</a>"])
             (htmls ("a" @: ["key" @= "value"]))
 
-    -- ,   scrapeTest
-    --         "<a><b><c>foo</c></b></a>"
-    --         (Just ["<c>foo</c>"])
-    --         (htmls ("a" // "b" @: [] // "c"))
+    ,   scrapeTest
+            "<a><b><c>foo</c></b></a>"
+            (Just ["<c>foo</c>"])
+            (htmls ("a" // "b" @: [] // "c"))
 
     ,   scrapeTest
             "<c><a><b>foo</b></a></c><c><a><d><b>bar</b></d></a></c><b>baz</b>"
             (Just ["<b>foo</b>", "<b>bar</b>"])
             (htmls ("a" // "b"))
 
-    -- ,   scrapeTest
-    --         "<a class=\"a b\">foo</a>"
-    --         (Just ["<a class=\"a b\">foo</a>"])
-    --         (htmls ("a" @: [hasClass "a"]))
+    ,   scrapeTest
+            "<a class=\"a b\">foo</a>"
+            (Just ["<a class=\"a b\">foo</a>"])
+            (htmls ("a" @: [hasClass "a"]))
 
-    -- ,   scrapeTest
-    --         "<a class=\"a b\">foo</a>"
-    --         Nothing
-    --         (htmls ("a" @: [hasClass "c"]))
+    ,   scrapeTest
+            "<a class=\"a b\">foo</a>"
+            Nothing
+            (htmls ("a" @: [hasClass "c"]))
 
-    -- ,   scrapeTest
-    --         "<a key=\"value\">foo</a>"
-    --         (Just ["<a key=\"value\">foo</a>"])
-    --         (htmls ("a" @: ["key" @=~ re "va(foo|bar|lu)e"]))
+    ,   scrapeTest
+            "<a key=\"value\">foo</a>"
+            (Just ["<a key=\"value\">foo</a>"])
+            (htmls ("a" @: ["key" @=~ re "va(foo|bar|lu)e"]))
 
-    -- ,   scrapeTest
-    --         "<a foo=\"value\">foo</a><a bar=\"value\">bar</a>"
-    --         (Just ["<a foo=\"value\">foo</a>", "<a bar=\"value\">bar</a>"])
-    --         (htmls ("a" @: [Any @= "value"]))
+    ,   scrapeTest
+            "<a foo=\"value\">foo</a><a bar=\"value\">bar</a>"
+            (Just ["<a foo=\"value\">foo</a>", "<a bar=\"value\">bar</a>"])
+            (htmls ("a" @: [AnyAttribute @= "value"]))
 
-    -- ,   scrapeTest
-    --         "<a foo=\"other\">foo</a><a bar=\"value\">bar</a>"
-    --         (Just ["<a bar=\"value\">bar</a>"])
-    --         (htmls ("a" @: [Any @= "value"]))
+    ,   scrapeTest
+            "<a foo=\"other\">foo</a><a bar=\"value\">bar</a>"
+            (Just ["<a bar=\"value\">bar</a>"])
+            (htmls ("a" @: [AnyAttribute @= "value"]))
 
-    -- ,   scrapeTest
-    --         "<a foo=\"value\">foo</a><b bar=\"value\">bar</b>"
-    --         (Just ["<a foo=\"value\">foo</a>", "<b bar=\"value\">bar</b>"])
-    --         (htmls (Any @: [Any @= "value"]))
+    ,   scrapeTest
+            "<a foo=\"value\">foo</a><b bar=\"value\">bar</b>"
+            (Just ["<a foo=\"value\">foo</a>", "<b bar=\"value\">bar</b>"])
+            (htmls (AnyTag @: [AnyAttribute @= "value"]))
 
-    -- ,   scrapeTest
-    --         "<a foo=\"other\">foo</a><b bar=\"value\">bar</b>"
-    --         (Just ["<b bar=\"value\">bar</b>"])
-    --         (htmls (Any @: [Any @= "value"]))
+    ,   scrapeTest
+            "<a foo=\"other\">foo</a><b bar=\"value\">bar</b>"
+            (Just ["<b bar=\"value\">bar</b>"])
+            (htmls (AnyTag @: [AnyAttribute @= "value"]))
 
-    -- ,   scrapeTest
-    --         "<a foo=\"bar\">1</a><a foo=\"foo\">2</a><a bar=\"bar\">3</a>"
-    --         (Just ["<a foo=\"foo\">2</a>", "<a bar=\"bar\">3</a>"])
-    --         (htmls (Any @: [match (==)]))
+    ,   scrapeTest
+            "<a foo=\"bar\">1</a><a foo=\"foo\">2</a><a bar=\"bar\">3</a>"
+            (Just ["<a foo=\"foo\">2</a>", "<a bar=\"bar\">3</a>"])
+            (htmls (AnyTag @: [match (==)]))
 
     ,   scrapeTest
             "<a>foo</a>"
@@ -120,138 +120,138 @@ scrapeTests = "scrapeTests" ~: TestList [
             (Just "foo")
             (text "a")
 
-    -- ,   scrapeTest
-    --         "<a>foo</a><a>bar</a>"
-    --         (Just ["foo", "bar"])
-    --         (texts "a")
+    ,   scrapeTest
+            "<a>foo</a><a>bar</a>"
+            (Just ["foo", "bar"])
+            (texts "a")
 
-    -- ,   scrapeTest
-    --         "<a>foo</a><a>bar</a>"
-    --         (Just [True, False])
-    --         (map (== "foo") <$> texts "a")
+    ,   scrapeTest
+            "<a>foo</a><a>bar</a>"
+            (Just [True, False])
+            (map (== "foo") <$> texts "a")
 
-    -- ,   scrapeTest
-    --         "<a key=foo />"
-    --         (Just "foo")
-    --         (attr "key" "a")
+    ,   scrapeTest
+            "<a key=foo />"
+            (Just "foo")
+            (attr "key" "a")
 
-    -- ,   scrapeTest
-    --         "<a key1=foo/><b key1=bar key2=foo /><a key1=bar key2=baz />"
-    --         (Just "baz")
-    --         (attr "key2" $ "a" @: ["key1" @= "bar"])
+    ,   scrapeTest
+            "<a key1=foo/><b key1=bar key2=foo /><a key1=bar key2=baz />"
+            (Just "baz")
+            (attr "key2" $ "a" @: ["key1" @= "bar"])
 
-    -- ,   scrapeTest
-    --         "<a><b>foo</b></a><b>bar</b>"
-    --         (Just ["foo"])
-    --         (chroot "a" $ texts "b")
+    ,   scrapeTest
+            "<a><b>foo</b></a><b>bar</b>"
+            (Just ["foo"])
+            (chroot "a" $ texts "b")
 
-    -- ,   scrapeTest
-    --         "<a><b>foo</b></a><a><b>bar</b></a>"
-    --         (Just ["foo", "bar"])
-    --         (chroots "a" $ text "b")
+    ,   scrapeTest
+            "<a><b>foo</b></a><a><b>bar</b></a>"
+            (Just ["foo", "bar"])
+            (chroots "a" $ text "b")
 
-    -- ,   scrapeTest
-    --         "<a><b>foo</b></a><a><c>bar</c></a>"
-    --         (Just "foo")
-    --         (text ("a" // "b") <|> text ("a" // "c"))
+    ,   scrapeTest
+            "<a><b>foo</b></a><a><c>bar</c></a>"
+            (Just "foo")
+            (text ("a" // "b") <|> text ("a" // "c"))
 
-    -- ,   scrapeTest
-    --         "<a><b>foo</b></a><a><c>bar</c></a>"
-    --         (Just "bar")
-    --         (text ("a" // "d") <|> text ("a" // "c"))
+    ,   scrapeTest
+            "<a><b>foo</b></a><a><c>bar</c></a>"
+            (Just "bar")
+            (text ("a" // "d") <|> text ("a" // "c"))
 
-    -- ,   scrapeTest
-    --         "<img src='foobar'>"
-    --         (Just "foobar")
-    --         (attr "src" "img")
+    ,   scrapeTest
+            "<img src='foobar'>"
+            (Just "foobar")
+            (attr "src" "img")
 
-    -- ,   scrapeTest
-    --         "<img src='foobar' />"
-    --         (Just "foobar")
-    --         (attr "src" "img")
+    ,   scrapeTest
+            "<img src='foobar' />"
+            (Just "foobar")
+            (attr "src" "img")
 
-    -- ,   scrapeTest
-    --         "<a>foo</a><A>bar</A>"
-    --         (Just ["foo", "bar"])
-    --         (texts "a")
+    ,   scrapeTest
+            "<a>foo</a><A>bar</A>"
+            (Just ["foo", "bar"])
+            (texts "a")
 
-    -- ,   scrapeTest
-    --         "<a>foo</a><A>bar</A>"
-    --         (Just ["foo", "bar"])
-    --         (texts "A")
+    ,   scrapeTest
+            "<a>foo</a><A>bar</A>"
+            (Just ["foo", "bar"])
+            (texts "A")
 
-    -- ,   scrapeTest
-    --         "<a B=C>foo</a>"
-    --         (Just ["foo"])
-    --         (texts $ "A" @: ["b" @= "C"])
+    ,   scrapeTest
+            "<a B=C>foo</a>"
+            (Just ["foo"])
+            (texts $ "A" @: ["b" @= "C"])
 
-    -- ,   scrapeTest
-    --         "<a B=C>foo</a>"
-    --         Nothing
-    --         (texts $ "A" @: ["b" @= "c"])
+    ,   scrapeTest
+            "<a B=C>foo</a>"
+            Nothing
+            (texts $ "A" @: ["b" @= "c"])
 
-    -- ,   scrapeTest
-    --         "<a>foo</a>"
-    --         (Just "<a>foo</a>")
-    --         (html "a")
+    ,   scrapeTest
+            "<a>foo</a>"
+            (Just "<a>foo</a>")
+            (html "a")
 
-    -- ,   scrapeTest
-    --         "<body><div><ul><li>1</li><li>2</li></ul></div></body>"
-    --         (Just "<li>1</li>")
-    --         (html "li")
+    ,   scrapeTest
+            "<body><div><ul><li>1</li><li>2</li></ul></div></body>"
+            (Just "<li>1</li>")
+            (html "li")
 
-    -- ,   scrapeTest
-    --         "<body><div></div></body>"
-    --         (Just "<div></div>")
-    --         (html "div")
+    ,   scrapeTest
+            "<body><div></div></body>"
+            (Just "<div></div>")
+            (html "div")
 
-    -- ,   scrapeTest
-    --         "<a>foo</a><a>bar</a>"
-    --         (Just ["<a>foo</a>","<a>bar</a>"])
-    --         (htmls "a")
+    ,   scrapeTest
+            "<a>foo</a><a>bar</a>"
+            (Just ["<a>foo</a>","<a>bar</a>"])
+            (htmls "a")
 
-    -- ,   scrapeTest
-    --         "<body><div><ul><li>1</li><li>2</li></ul></div></body>"
-    --         (Just ["<li>1</li>", "<li>2</li>"])
-    --         (htmls "li")
+    ,   scrapeTest
+            "<body><div><ul><li>1</li><li>2</li></ul></div></body>"
+            (Just ["<li>1</li>", "<li>2</li>"])
+            (htmls "li")
 
-    -- ,   scrapeTest
-    --         "<body><div></div></body>"
-    --         (Just ["<div></div>"])
-    --         (htmls "div")
+    ,   scrapeTest
+            "<body><div></div></body>"
+            (Just ["<div></div>"])
+            (htmls "div")
 
-    -- ,   scrapeTest
-    --         "<a>1<b>2</b>3</a>"
-    --         (Just "1<b>2</b>3")
-    --         (innerHTML anySelector)
+    ,   scrapeTest
+            "<a>1<b>2</b>3</a>"
+            (Just "1<b>2</b>3")
+            (innerHTML anySelector)
 
-    -- ,   scrapeTest
-    --         "<a>"
-    --         (Just "")
-    --         (innerHTML anySelector)
+    ,   scrapeTest
+            "<a>"
+            (Just "")
+            (innerHTML anySelector)
 
-    -- ,   scrapeTest
-    --         "<a>foo</a><a>bar</a>"
-    --         (Just ["foo","bar"])
-    --         (innerHTMLs "a")
+    ,   scrapeTest
+            "<a>foo</a><a>bar</a>"
+            (Just ["foo","bar"])
+            (innerHTMLs "a")
 
-    -- ,   scrapeTest
-    --         "<a>foo</a><a>bar</a><a>baz</a>"
-    --         (Just "<a>bar</a>")
-    --         (chroot "a" $ do
-    --             t <- text anySelector
-    --             guard ("b" `isInfixOf` t)
-    --             html anySelector)
+    ,   scrapeTest
+            "<a>foo</a><a>bar</a><a>baz</a>"
+            (Just "<a>bar</a>")
+            (chroot "a" $ do
+                t <- text anySelector
+                guard ("b" `isInfixOf` t)
+                html anySelector)
 
-    -- ,   scrapeTest
-    --         "<div id=\"outer\"><div id=\"inner\">inner text</div></div>"
-    --         (Just ["inner"])
-    --         (attrs "id" ("div" // "div"))
+    ,   scrapeTest
+            "<div id=\"outer\"><div id=\"inner\">inner text</div></div>"
+            (Just ["inner"])
+            (attrs "id" ("div" // "div"))
 
-    -- ,   scrapeTest
-    --         "<div id=\"a\"><div id=\"b\"><div id=\"c\"></div></div></div>"
-    --         (Just ["b", "c"])
-    --         (attrs "id" ("div" // "div"))
+    ,   scrapeTest
+            "<div id=\"a\"><div id=\"b\"><div id=\"c\"></div></div></div>"
+            (Just ["b", "c"])
+            (attrs "id" ("div" // "div"))
 
     ,   scrapeTest
             "<a>1<b>2<c>3</c>4</b>5</a>"

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
 import Text.HTML.Scalpel
@@ -26,87 +27,87 @@ scrapeTests = "scrapeTests" ~: TestList [
         scrapeTest
             "<a>foo</a>"
             (Just ["<a>foo</a>"])
-            (htmls ("a" @: []))
+            (htmls (("a" :: String) @: []))
 
     ,   scrapeTest
             "<a>foo</a><a>bar</a>"
             (Just ["<a>foo</a>", "<a>bar</a>"])
-            (htmls ("a" @: []))
+            (htmls (("a" :: String) @: []))
 
-    ,   scrapeTest
-            "<b><a>foo</a></b>"
-            (Just ["<a>foo</a>"])
-            (htmls ("a" @: []))
+    -- ,   scrapeTest
+    --         "<b><a>foo</a></b>"
+    --         (Just ["<a>foo</a>"])
+    --         (htmls ("a" @: []))
 
-    ,   scrapeTest
-            "<a><a>foo</a></a>"
-            (Just ["<a><a>foo</a></a>", "<a>foo</a>"])
-            (htmls ("a" @: []))
+    -- ,   scrapeTest
+    --         "<a><a>foo</a></a>"
+    --         (Just ["<a><a>foo</a></a>", "<a>foo</a>"])
+    --         (htmls ("a" @: []))
 
-    ,   scrapeTest
-            "<a>foo</a>"
-            Nothing
-            (htmls ("b" @: []))
+    -- ,   scrapeTest
+    --         "<a>foo</a>"
+    --         Nothing
+    --         (htmls ("b" @: []))
 
-    ,   scrapeTest
-            "<a>foo"
-            (Just ["<a>"])
-            (htmls ("a" @: []))
+    -- ,   scrapeTest
+    --         "<a>foo"
+    --         (Just ["<a>"])
+    --         (htmls ("a" @: []))
 
-    ,   scrapeTest
-            "<a>foo</a><a key=\"value\">bar</a>"
-            (Just ["<a key=\"value\">bar</a>"])
-            (htmls ("a" @: ["key" @= "value"]))
+    -- ,   scrapeTest
+    --         "<a>foo</a><a key=\"value\">bar</a>"
+    --         (Just ["<a key=\"value\">bar</a>"])
+    --         (htmls ("a" @: ["key" @= "value"]))
 
-    ,   scrapeTest
-            "<a><b><c>foo</c></b></a>"
-            (Just ["<c>foo</c>"])
-            (htmls ("a" // "b" @: [] // "c"))
+    -- ,   scrapeTest
+    --         "<a><b><c>foo</c></b></a>"
+    --         (Just ["<c>foo</c>"])
+    --         (htmls ("a" // "b" @: [] // "c"))
 
     ,   scrapeTest
             "<c><a><b>foo</b></a></c><c><a><d><b>bar</b></d></a></c><b>baz</b>"
             (Just ["<b>foo</b>", "<b>bar</b>"])
             (htmls ("a" // "b"))
 
-    ,   scrapeTest
-            "<a class=\"a b\">foo</a>"
-            (Just ["<a class=\"a b\">foo</a>"])
-            (htmls ("a" @: [hasClass "a"]))
+    -- ,   scrapeTest
+    --         "<a class=\"a b\">foo</a>"
+    --         (Just ["<a class=\"a b\">foo</a>"])
+    --         (htmls ("a" @: [hasClass "a"]))
 
-    ,   scrapeTest
-            "<a class=\"a b\">foo</a>"
-            Nothing
-            (htmls ("a" @: [hasClass "c"]))
+    -- ,   scrapeTest
+    --         "<a class=\"a b\">foo</a>"
+    --         Nothing
+    --         (htmls ("a" @: [hasClass "c"]))
 
-    ,   scrapeTest
-            "<a key=\"value\">foo</a>"
-            (Just ["<a key=\"value\">foo</a>"])
-            (htmls ("a" @: ["key" @=~ re "va(foo|bar|lu)e"]))
+    -- ,   scrapeTest
+    --         "<a key=\"value\">foo</a>"
+    --         (Just ["<a key=\"value\">foo</a>"])
+    --         (htmls ("a" @: ["key" @=~ re "va(foo|bar|lu)e"]))
 
-    ,   scrapeTest
-            "<a foo=\"value\">foo</a><a bar=\"value\">bar</a>"
-            (Just ["<a foo=\"value\">foo</a>", "<a bar=\"value\">bar</a>"])
-            (htmls ("a" @: [Any @= "value"]))
+    -- ,   scrapeTest
+    --         "<a foo=\"value\">foo</a><a bar=\"value\">bar</a>"
+    --         (Just ["<a foo=\"value\">foo</a>", "<a bar=\"value\">bar</a>"])
+    --         (htmls ("a" @: [Any @= "value"]))
 
-    ,   scrapeTest
-            "<a foo=\"other\">foo</a><a bar=\"value\">bar</a>"
-            (Just ["<a bar=\"value\">bar</a>"])
-            (htmls ("a" @: [Any @= "value"]))
+    -- ,   scrapeTest
+    --         "<a foo=\"other\">foo</a><a bar=\"value\">bar</a>"
+    --         (Just ["<a bar=\"value\">bar</a>"])
+    --         (htmls ("a" @: [Any @= "value"]))
 
-    ,   scrapeTest
-            "<a foo=\"value\">foo</a><b bar=\"value\">bar</b>"
-            (Just ["<a foo=\"value\">foo</a>", "<b bar=\"value\">bar</b>"])
-            (htmls (Any @: [Any @= "value"]))
+    -- ,   scrapeTest
+    --         "<a foo=\"value\">foo</a><b bar=\"value\">bar</b>"
+    --         (Just ["<a foo=\"value\">foo</a>", "<b bar=\"value\">bar</b>"])
+    --         (htmls (Any @: [Any @= "value"]))
 
-    ,   scrapeTest
-            "<a foo=\"other\">foo</a><b bar=\"value\">bar</b>"
-            (Just ["<b bar=\"value\">bar</b>"])
-            (htmls (Any @: [Any @= "value"]))
+    -- ,   scrapeTest
+    --         "<a foo=\"other\">foo</a><b bar=\"value\">bar</b>"
+    --         (Just ["<b bar=\"value\">bar</b>"])
+    --         (htmls (Any @: [Any @= "value"]))
 
-    ,   scrapeTest
-            "<a foo=\"bar\">1</a><a foo=\"foo\">2</a><a bar=\"bar\">3</a>"
-            (Just ["<a foo=\"foo\">2</a>", "<a bar=\"bar\">3</a>"])
-            (htmls (Any @: [match (==)]))
+    -- ,   scrapeTest
+    --         "<a foo=\"bar\">1</a><a foo=\"foo\">2</a><a bar=\"bar\">3</a>"
+    --         (Just ["<a foo=\"foo\">2</a>", "<a bar=\"bar\">3</a>"])
+    --         (htmls (Any @: [match (==)]))
 
     ,   scrapeTest
             "<a>foo</a>"
@@ -118,143 +119,143 @@ scrapeTests = "scrapeTests" ~: TestList [
             (Just "foo")
             (text "a")
 
-    ,   scrapeTest
-            "<a>foo</a><a>bar</a>"
-            (Just ["foo", "bar"])
-            (texts "a")
+    -- ,   scrapeTest
+    --         "<a>foo</a><a>bar</a>"
+    --         (Just ["foo", "bar"])
+    --         (texts "a")
 
-    ,   scrapeTest
-            "<a>foo</a><a>bar</a>"
-            (Just [True, False])
-            (map (== "foo") <$> texts "a")
+    -- ,   scrapeTest
+    --         "<a>foo</a><a>bar</a>"
+    --         (Just [True, False])
+    --         (map (== "foo") <$> texts "a")
 
-    ,   scrapeTest
-            "<a key=foo />"
-            (Just "foo")
-            (attr "key" "a")
+    -- ,   scrapeTest
+    --         "<a key=foo />"
+    --         (Just "foo")
+    --         (attr "key" "a")
 
-    ,   scrapeTest
-            "<a key1=foo/><b key1=bar key2=foo /><a key1=bar key2=baz />"
-            (Just "baz")
-            (attr "key2" $ "a" @: ["key1" @= "bar"])
+    -- ,   scrapeTest
+    --         "<a key1=foo/><b key1=bar key2=foo /><a key1=bar key2=baz />"
+    --         (Just "baz")
+    --         (attr "key2" $ "a" @: ["key1" @= "bar"])
 
-    ,   scrapeTest
-            "<a><b>foo</b></a><b>bar</b>"
-            (Just ["foo"])
-            (chroot "a" $ texts "b")
+    -- ,   scrapeTest
+    --         "<a><b>foo</b></a><b>bar</b>"
+    --         (Just ["foo"])
+    --         (chroot "a" $ texts "b")
 
-    ,   scrapeTest
-            "<a><b>foo</b></a><a><b>bar</b></a>"
-            (Just ["foo", "bar"])
-            (chroots "a" $ text "b")
+    -- ,   scrapeTest
+    --         "<a><b>foo</b></a><a><b>bar</b></a>"
+    --         (Just ["foo", "bar"])
+    --         (chroots "a" $ text "b")
 
-    ,   scrapeTest
-            "<a><b>foo</b></a><a><c>bar</c></a>"
-            (Just "foo")
-            (text ("a" // "b") <|> text ("a" // "c"))
+    -- ,   scrapeTest
+    --         "<a><b>foo</b></a><a><c>bar</c></a>"
+    --         (Just "foo")
+    --         (text ("a" // "b") <|> text ("a" // "c"))
 
-    ,   scrapeTest
-            "<a><b>foo</b></a><a><c>bar</c></a>"
-            (Just "bar")
-            (text ("a" // "d") <|> text ("a" // "c"))
+    -- ,   scrapeTest
+    --         "<a><b>foo</b></a><a><c>bar</c></a>"
+    --         (Just "bar")
+    --         (text ("a" // "d") <|> text ("a" // "c"))
 
-    ,   scrapeTest
-            "<img src='foobar'>"
-            (Just "foobar")
-            (attr "src" "img")
+    -- ,   scrapeTest
+    --         "<img src='foobar'>"
+    --         (Just "foobar")
+    --         (attr "src" "img")
 
-    ,   scrapeTest
-            "<img src='foobar' />"
-            (Just "foobar")
-            (attr "src" "img")
+    -- ,   scrapeTest
+    --         "<img src='foobar' />"
+    --         (Just "foobar")
+    --         (attr "src" "img")
 
-    ,   scrapeTest
-            "<a>foo</a><A>bar</A>"
-            (Just ["foo", "bar"])
-            (texts "a")
+    -- ,   scrapeTest
+    --         "<a>foo</a><A>bar</A>"
+    --         (Just ["foo", "bar"])
+    --         (texts "a")
 
-    ,   scrapeTest
-            "<a>foo</a><A>bar</A>"
-            (Just ["foo", "bar"])
-            (texts "A")
+    -- ,   scrapeTest
+    --         "<a>foo</a><A>bar</A>"
+    --         (Just ["foo", "bar"])
+    --         (texts "A")
 
-    ,   scrapeTest
-            "<a B=C>foo</a>"
-            (Just ["foo"])
-            (texts $ "A" @: ["b" @= "C"])
+    -- ,   scrapeTest
+    --         "<a B=C>foo</a>"
+    --         (Just ["foo"])
+    --         (texts $ "A" @: ["b" @= "C"])
 
-    ,   scrapeTest
-            "<a B=C>foo</a>"
-            Nothing
-            (texts $ "A" @: ["b" @= "c"])
+    -- ,   scrapeTest
+    --         "<a B=C>foo</a>"
+    --         Nothing
+    --         (texts $ "A" @: ["b" @= "c"])
 
-    ,   scrapeTest
-            "<a>foo</a>"
-            (Just "<a>foo</a>")
-            (html "a")
+    -- ,   scrapeTest
+    --         "<a>foo</a>"
+    --         (Just "<a>foo</a>")
+    --         (html "a")
 
-    ,   scrapeTest
-            "<body><div><ul><li>1</li><li>2</li></ul></div></body>"
-            (Just "<li>1</li>")
-            (html "li")
+    -- ,   scrapeTest
+    --         "<body><div><ul><li>1</li><li>2</li></ul></div></body>"
+    --         (Just "<li>1</li>")
+    --         (html "li")
 
-    ,   scrapeTest
-            "<body><div></div></body>"
-            (Just "<div></div>")
-            (html "div")
+    -- ,   scrapeTest
+    --         "<body><div></div></body>"
+    --         (Just "<div></div>")
+    --         (html "div")
 
-    ,   scrapeTest
-            "<a>foo</a><a>bar</a>"
-            (Just ["<a>foo</a>","<a>bar</a>"])
-            (htmls "a")
+    -- ,   scrapeTest
+    --         "<a>foo</a><a>bar</a>"
+    --         (Just ["<a>foo</a>","<a>bar</a>"])
+    --         (htmls "a")
 
-    ,   scrapeTest
-            "<body><div><ul><li>1</li><li>2</li></ul></div></body>"
-            (Just ["<li>1</li>", "<li>2</li>"])
-            (htmls "li")
+    -- ,   scrapeTest
+    --         "<body><div><ul><li>1</li><li>2</li></ul></div></body>"
+    --         (Just ["<li>1</li>", "<li>2</li>"])
+    --         (htmls "li")
 
-    ,   scrapeTest
-            "<body><div></div></body>"
-            (Just ["<div></div>"])
-            (htmls "div")
+    -- ,   scrapeTest
+    --         "<body><div></div></body>"
+    --         (Just ["<div></div>"])
+    --         (htmls "div")
 
-    ,   scrapeTest
-            "<a>1<b>2</b>3</a>"
-            (Just "1<b>2</b>3")
-            (innerHTML Any)
+    -- ,   scrapeTest
+    --         "<a>1<b>2</b>3</a>"
+    --         (Just "1<b>2</b>3")
+    --         (innerHTML anySelector)
 
-    ,   scrapeTest
-            "<a>"
-            (Just "")
-            (innerHTML Any)
+    -- ,   scrapeTest
+    --         "<a>"
+    --         (Just "")
+    --         (innerHTML anySelector)
 
-    ,   scrapeTest
-            "<a>foo</a><a>bar</a>"
-            (Just ["foo","bar"])
-            (innerHTMLs "a")
+    -- ,   scrapeTest
+    --         "<a>foo</a><a>bar</a>"
+    --         (Just ["foo","bar"])
+    --         (innerHTMLs "a")
 
-    ,   scrapeTest
-            "<a>foo</a><a>bar</a><a>baz</a>"
-            (Just "<a>bar</a>")
-            (chroot "a" $ do
-                t <- text Any
-                guard ("b" `isInfixOf` t)
-                html Any)
+    -- ,   scrapeTest
+    --         "<a>foo</a><a>bar</a><a>baz</a>"
+    --         (Just "<a>bar</a>")
+    --         (chroot "a" $ do
+    --             t <- text anySelector
+    --             guard ("b" `isInfixOf` t)
+    --             html anySelector)
 
-    ,   scrapeTest
-            "<div id=\"outer\"><div id=\"inner\">inner text</div></div>"
-            (Just ["inner"])
-            (attrs "id" ("div" // "div"))
+    -- ,   scrapeTest
+    --         "<div id=\"outer\"><div id=\"inner\">inner text</div></div>"
+    --         (Just ["inner"])
+    --         (attrs "id" ("div" // "div"))
 
-    ,   scrapeTest
-            "<div id=\"a\"><div id=\"b\"><div id=\"c\"></div></div></div>"
-            (Just ["b", "c"])
-            (attrs "id" ("div" // "div"))
+    -- ,   scrapeTest
+    --         "<div id=\"a\"><div id=\"b\"><div id=\"c\"></div></div></div>"
+    --         (Just ["b", "c"])
+    --         (attrs "id" ("div" // "div"))
 
     ,   scrapeTest
             "<a>1<b>2<c>3</c>4</b>5</a>"
             (Just "12345")
-            (text Any)
+            (text anySelector)
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test


### PR DESCRIPTION
This addresses Issue #29.

I've removed the classes `Selectable`, `TagName`, and `AttributeName` and replaced the last two with suitable data types.

I took @debug-ito's suggestions when altering `Selector` and `Selectable`. Does everyone approve of how I've chosen to change `TagName` and `AttributeName`?