### PR TITLE
(#43) Implement fail as mzero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Fix backtracking that occurs when using `guard` and `chroot`.
 - Fix bug where the same tag may appear in the result set multiple times.
 - Performance optimizations when using the (//) operator.
+- Make Scraper an instance of MonadFail. Practically this means that failed
+  pattern matches in `<-` expressions within a do block will evaluate to mzero
+  instead of throwing an error and bringing down the entire script.
 
 ## 0.3.1
 

--- a/scalpel.cabal
+++ b/scalpel.cabal
@@ -47,6 +47,7 @@ library
       ,   containers
       ,   curl          >= 1.3.4
       ,   data-default
+      ,   fail
       ,   regex-base
       ,   regex-tdfa
       ,   tagsoup       >= 0.12.2

--- a/src/Text/HTML/Scalpel/Internal/Scrape.hs
+++ b/src/Text/HTML/Scalpel/Internal/Scrape.hs
@@ -21,8 +21,9 @@ import Control.Applicative
 import Control.Monad
 import Data.Maybe
 
-import qualified Text.HTML.TagSoup as TagSoup
+import qualified Control.Monad.Fail as Fail
 import qualified Data.Vector as Vector
+import qualified Text.HTML.TagSoup as TagSoup
 import qualified Text.StringLike as TagSoup
 
 
@@ -48,6 +49,7 @@ instance Alternative (Scraper str) where
                           | otherwise             = b tags
 
 instance Monad (Scraper str) where
+    fail = Fail.fail
     return = pure
     (MkScraper a) >>= f = MkScraper combined
         where combined tags | (Just aVal) <- a tags = let (MkScraper b) = f aVal
@@ -57,6 +59,9 @@ instance Monad (Scraper str) where
 instance MonadPlus (Scraper str) where
     mzero = empty
     mplus = (<|>)
+
+instance Fail.MonadFail (Scraper str) where
+    fail _ = mzero
 
 -- | The 'scrape' function executes a 'Scraper' on a list of
 -- 'TagSoup.Tag's and produces an optional value.

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,6 @@ flags: {}
 packages:
 - '.'
 - examples/
-extra-deps: []
-resolver: lts-5.1
+extra-deps:
+- fail-4.9.0.0
+resolver: lts-7.4

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -257,6 +257,20 @@ scrapeTests = "scrapeTests" ~: TestList [
             "<a>1<b>2<c>3</c>4</b>5</a>"
             (Just "12345")
             (text anySelector)
+
+    ,   scrapeTest
+            "<a>1</a>"
+            Nothing
+            $ do
+                "Bad pattern" <- text "a"
+                return "OK"
+
+    ,   scrapeTest
+            "<a>1</a>"
+            (Just "OK")
+            $ do
+                "1" <- text "a"
+                return "OK"
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test


### PR DESCRIPTION
Scraper is made an instance of MonadFail using the transitional fail
package (https://hackage.haskell.org/package/fail). This allows
pattern matching in `<-` expressions to be evaluated to `mzero` when
the match fails instead of throwing an error.