### PR TITLE
(#44) Make `withAll` always succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix backtracking that occurs when using `guard` and `chroot`.
 - Fix bug where the same tag may appear in the result set multiple times.
 - Performance optimizations when using the (//) operator.
+- Pluralized scrapers will now return the empty list instead mzero when there
+  are no matches.
 
 ## 0.3.1
 

--- a/src/Text/HTML/Scalpel/Internal/Scrape.hs
+++ b/src/Text/HTML/Scalpel/Internal/Scrape.hs
@@ -155,7 +155,6 @@ withHead _ []    = Nothing
 withHead f (x:_) = Just $ f x
 
 withAll :: (a -> b) -> [a] -> Maybe [b]
-withAll _ [] = Nothing
 withAll f xs = Just $ map f xs
 
 foldSpec :: TagSoup.StringLike str

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -47,7 +47,7 @@ scrapeTests = "scrapeTests" ~: TestList [
 
     ,   scrapeTest
             "<a>foo</a>"
-            Nothing
+            (Just [])
             (htmls ("b" @: []))
 
     ,   scrapeTest
@@ -77,7 +77,7 @@ scrapeTests = "scrapeTests" ~: TestList [
 
     ,   scrapeTest
             "<a class=\"a b\">foo</a>"
-            Nothing
+            (Just [])
             (htmls ("a" @: [hasClass "c"]))
 
     ,   scrapeTest
@@ -187,7 +187,7 @@ scrapeTests = "scrapeTests" ~: TestList [
 
     ,   scrapeTest
             "<a B=C>foo</a>"
-            Nothing
+            (Just [])
             (texts $ "A" @: ["b" @= "c"])
 
     ,   scrapeTest


### PR DESCRIPTION
This makes the pluralized scrapers return an empty list instead of
failing if there are no matching elements.