### PR TITLE
(#38) Add position scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   instead of throwing an error and bringing down the entire script.
 - Pluralized scrapers will now return the empty list instead mzero when there
   are no matches.
+- Add the `position` scraper which provides the index of the current sub-tree
+  within the context of a `chroots`'s do-block.
 
 ## 0.3.1
 

--- a/src/Text/HTML/Scalpel.hs
+++ b/src/Text/HTML/Scalpel.hs
@@ -128,6 +128,7 @@ module Text.HTML.Scalpel (
 ,   texts
 ,   chroot
 ,   chroots
+,   position
 -- ** Executing scrapers
 ,   scrape
 ,   scrapeStringLike

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -271,6 +271,21 @@ scrapeTests = "scrapeTests" ~: TestList [
             $ do
                 "1" <- text "a"
                 return "OK"
+    ,   scrapeTest
+            "<article><p>A</p><p>B</p><p>C</p></article>"
+            (Just [(0, "A"), (1, "B"), (2, "C")])
+            (chroots ("article" // "p") $ do
+                index   <- position
+                content <- text anySelector
+                return (index, content))
+
+    ,   scrapeTest
+            "<article><p>A</p></article><article><p>B</p><p>C</p></article>"
+            (Just [[(0, "A")], [(0, "B"), (1, "C")]])
+            (chroots "article" $ chroots "p" $ do
+                index   <- position
+                content <- text anySelector
+                return (index, content))
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test


### PR DESCRIPTION
The position scraper returns the index of the current sub-tree within
the context of a `chroots` do-block.