### PR TITLE
 Remove `Ord` constraint from public APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## HEAD
 
+- Remove `Ord` constraint from public APIs.
+
 ## 0.5.1
 
 - Fix bug (#59, #54) in DFS traversal order.

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape.hs
@@ -66,7 +66,7 @@ instance Fail.MonadFail (Scraper str) where
 
 -- | The 'scrape' function executes a 'Scraper' on a list of
 -- 'TagSoup.Tag's and produces an optional value.
-scrape :: (Ord str, TagSoup.StringLike str)
+scrape :: (TagSoup.StringLike str)
        => Scraper str a -> [TagSoup.Tag str] -> Maybe a
 scrape s = scrapeTagSpec s . tagsToSpec . TagSoup.canonicalizeTags
 
@@ -76,7 +76,7 @@ scrape s = scrapeTagSpec s . tagsToSpec . TagSoup.canonicalizeTags
 --
 -- This function will match only the first set of tags matching the selector, to
 -- match every set of tags, use 'chroots'.
-chroot :: (Ord str, TagSoup.StringLike str)
+chroot :: (TagSoup.StringLike str)
        => Selector -> Scraper str a -> Scraper str a
 chroot selector inner = do
     maybeResult <- listToMaybe <$> chroots selector inner
@@ -90,7 +90,7 @@ chroot selector inner = do
 --
 -- > s = "<div><div>A</div></div>"
 -- > scrapeStringLike s (chroots "div" (pure 0)) == Just [0, 0]
-chroots :: (Ord str, TagSoup.StringLike str)
+chroots :: (TagSoup.StringLike str)
         => Selector -> Scraper str a -> Scraper str [a]
 chroots selector (MkScraper inner) = MkScraper
                                    $ return . mapMaybe inner . select selector
@@ -100,7 +100,7 @@ chroots selector (MkScraper inner) = MkScraper
 --
 -- This function will match only the first set of tags matching the selector, to
 -- match every set of tags, use 'texts'.
-text :: (Ord str, TagSoup.StringLike str) => Selector -> Scraper str str
+text :: (TagSoup.StringLike str) => Selector -> Scraper str str
 text s = MkScraper $ withHead tagsToText . select s
 
 -- | The 'texts' function takes a selector and returns the inner text from every
@@ -108,7 +108,7 @@ text s = MkScraper $ withHead tagsToText . select s
 --
 -- > s = "<div>Hello <div>World</div></div>"
 -- > scrapeStringLike s (texts "div") == Just ["Hello World", "World"]
-texts :: (Ord str, TagSoup.StringLike str)
+texts :: (TagSoup.StringLike str)
       => Selector -> Scraper str [str]
 texts s = MkScraper $ withAll tagsToText . select s
 
@@ -117,7 +117,7 @@ texts s = MkScraper $ withAll tagsToText . select s
 --
 -- This function will match only the first set of tags matching the selector, to
 -- match every set of tags, use 'htmls'.
-html :: (Ord str, TagSoup.StringLike str) => Selector -> Scraper str str
+html :: (TagSoup.StringLike str) => Selector -> Scraper str str
 html s = MkScraper $ withHead tagsToHTML . select s
 
 -- | The 'htmls' function takes a selector and returns the html string from
@@ -125,7 +125,7 @@ html s = MkScraper $ withHead tagsToHTML . select s
 --
 -- > s = "<div><div>A</div></div>"
 -- > scrapeStringLike s (htmls "div") == Just ["<div><div>A</div></div>", "<div>A</div>"]
-htmls :: (Ord str, TagSoup.StringLike str)
+htmls :: (TagSoup.StringLike str)
       => Selector -> Scraper str [str]
 htmls s = MkScraper $ withAll tagsToHTML . select s
 
@@ -135,7 +135,7 @@ htmls s = MkScraper $ withAll tagsToHTML . select s
 --
 -- This function will match only the first set of tags matching the selector, to
 -- match every set of tags, use 'innerHTMLs'.
-innerHTML :: (Ord str, TagSoup.StringLike str)
+innerHTML :: (TagSoup.StringLike str)
           => Selector -> Scraper str str
 innerHTML s = MkScraper $ withHead tagsToInnerHTML . select s
 
@@ -144,7 +144,7 @@ innerHTML s = MkScraper $ withHead tagsToInnerHTML . select s
 --
 -- > s = "<div><div>A</div></div>"
 -- > scrapeStringLike s (innerHTMLs "div") == Just ["<div>A</div>", "A"]
-innerHTMLs :: (Ord str, TagSoup.StringLike str)
+innerHTMLs :: (TagSoup.StringLike str)
            => Selector -> Scraper str [str]
 innerHTMLs s = MkScraper $ withAll tagsToInnerHTML . select s
 
@@ -154,7 +154,7 @@ innerHTMLs s = MkScraper $ withAll tagsToInnerHTML . select s
 --
 -- This function will match only the opening tag matching the selector, to match
 -- every tag, use 'attrs'.
-attr :: (Ord str, Show str, TagSoup.StringLike str)
+attr :: (Show str, TagSoup.StringLike str)
      => String -> Selector -> Scraper str str
 attr name s = MkScraper
             $ join . withHead (tagsToAttr $ TagSoup.castString name) . select s
@@ -165,7 +165,7 @@ attr name s = MkScraper
 --
 -- > s = "<div id=\"out\"><div id=\"in\"></div></div>"
 -- > scrapeStringLike s (attrs "id" "div") == Just ["out", "in"]
-attrs :: (Ord str, Show str, TagSoup.StringLike str)
+attrs :: (Show str, TagSoup.StringLike str)
      => String -> Selector -> Scraper str [str]
 attrs name s = MkScraper
              $ fmap catMaybes . withAll (tagsToAttr nameStr) . select s
@@ -205,7 +205,7 @@ attrs name s = MkScraper
 -- , (2, "Third paragraph.")
 -- ]
 -- @
-position :: (Ord str, TagSoup.StringLike str) => Scraper str Int
+position :: (TagSoup.StringLike str) => Scraper str Int
 position = MkScraper $ Just . tagsToPosition
 
 withHead :: (a -> b) -> [a] -> Maybe b

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape/StringLike.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape/StringLike.hs
@@ -11,7 +11,7 @@ import qualified Text.StringLike as TagSoup
 
 -- | The 'scrapeStringLike' function parses a 'StringLike' value into a list of
 -- tags and executes a 'Scraper' on it.
-scrapeStringLike :: (Ord str, TagSoup.StringLike str)
+scrapeStringLike :: (TagSoup.StringLike str)
                  => str -> Scraper str a -> Maybe a
 scrapeStringLike html scraper
     = scrape scraper (TagSoup.parseTagsOptions TagSoup.parseOptionsFast html)

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Select.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Select.hs
@@ -69,7 +69,7 @@ type TagSpec str = (TagVector str, TagForest, SelectContext)
 -- | The 'select' function takes a 'Selectable' value and a list of
 -- 'TagSoup.Tag's and returns a list of every subsequence of the given list of
 -- Tags that matches the given selector.
-select :: (Ord str, TagSoup.StringLike str)
+select :: (TagSoup.StringLike str)
        => Selector -> TagSpec str -> [TagSpec str]
 select s tagSpec = newSpecs
     where
@@ -78,7 +78,7 @@ select s tagSpec = newSpecs
         applyPosition p (tags, f, _) = (tags, f, SelectContext p)
 
 -- | Creates a TagSpec from a list of tags parsed by TagSoup.
-tagsToSpec :: forall str. (Ord str, TagSoup.StringLike str)
+tagsToSpec :: forall str. (TagSoup.StringLike str)
            => [TagSoup.Tag str] -> TagSpec str
 tagsToSpec tags = (vector, tree, ctx)
     where
@@ -108,7 +108,7 @@ tagsToSpec tags = (vector, tree, ctx)
 --          closing offset.
 --
 --      (5) The result set is then sorted by their indices.
-tagsToVector :: forall str. (Ord str, TagSoup.StringLike str)
+tagsToVector :: forall str. (TagSoup.StringLike str)
              => [TagSoup.Tag str] -> TagVector str
 tagsToVector tags = let indexed  = zip tags [0..]
                         total    = length indexed

--- a/scalpel/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
+++ b/scalpel/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
@@ -58,19 +58,19 @@ instance TagSoup.StringLike str => Default.Default (Config str) where
 -- require inbuilt networking support can depend on
 -- <https://hackage.haskell.org/package/scalpel-core scalpel-core> for a
 -- lightweight subset of this library that does not depend on curl.
-scrapeURL :: (Ord str, TagSoup.StringLike str)
+scrapeURL :: (TagSoup.StringLike str)
           => URL -> Scraper str a -> IO (Maybe a)
 scrapeURL = scrapeURLWithOpts [Curl.CurlFollowLocation True]
 
 -- | The 'scrapeURLWithOpts' function take a list of curl options and downloads
 -- the contents of the given URL and executes a 'Scraper' on it.
-scrapeURLWithOpts :: (Ord str, TagSoup.StringLike str)
+scrapeURLWithOpts :: (TagSoup.StringLike str)
                   => [Curl.CurlOption] -> URL -> Scraper str a -> IO (Maybe a)
 scrapeURLWithOpts options = scrapeURLWithConfig (def {curlOpts = options})
 
 -- | The 'scrapeURLWithConfig' function takes a 'Config' record type and
 -- downloads the contents of the given URL and executes a 'Scraper' on it.
-scrapeURLWithConfig :: (Ord str, TagSoup.StringLike str)
+scrapeURLWithConfig :: (TagSoup.StringLike str)
                   => Config str -> URL -> Scraper str a -> IO (Maybe a)
 scrapeURLWithConfig config url scraper = do
     maybeTags <- downloadAsTags (decoder config) url


### PR DESCRIPTION
This was a holdover from when when the underlying data type was used as
keys in map. Now Text is used everywhere internally and this is no
longer required.

Issue #61