### PR TITLE
Add `atDepth` operator and misc fixes and optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Remove `Ord` constraint from public APIs.
 - Add `atDepth` operator which allows for selecting nodes at a specified depth
   in relation to another node (#21).
+- Fix issue selecting malformed HTML where `"a" // "c"` would not match
+  `<a><b><c></c></a></b>`.
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## HEAD
 
 - Remove `Ord` constraint from public APIs.
+- Add `atDepth` operator which allows for selecting nodes at a specified depth
+  in relation to another node (#21).
 
 ## 0.5.1
 

--- a/scalpel-core/src/Text/HTML/Scalpel/Core.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Core.hs
@@ -22,6 +22,7 @@ module Text.HTML.Scalpel.Core (
 ,   anySelector
 -- ** Tag combinators
 ,   (//)
+,   atDepth
 -- ** Attribute predicates
 ,   (@:)
 ,   (@=)

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Select/Types.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Select/Types.hs
@@ -15,6 +15,8 @@ module Text.HTML.Scalpel.Internal.Select.Types (
 ,   tagSelector
 ,   anySelector
 ,   toSelectNode
+,   SelectSettings (..)
+,   defaultSelectSettings
 ) where
 
 import Data.Char (toLower)
@@ -56,14 +58,31 @@ anyAttrPredicate p = MkAttributePredicate $ any p
 -- | 'Selector' defines a selection of an HTML DOM tree to be operated on by
 -- a web scraper. The selection includes the opening tag that matches the
 -- selection, all of the inner tags, and the corresponding closing tag.
-newtype Selector = MkSelector [SelectNode]
+newtype Selector = MkSelector [(SelectNode, SelectSettings)]
+
+-- | 'SelectSettings' defines additional criteria for a Selector that must be
+-- satisfied in addition to the SelectNode. This includes criteria that are
+-- dependent on the context of the current node, for example the depth in
+-- relation to the previously matched SelectNode.
+data SelectSettings = SelectSettings {
+  -- | The required depth of the current select node in relation to the
+  -- previously matched SelectNode.
+  selectSettingsDepth :: Maybe Int
+}
+
+defaultSelectSettings :: SelectSettings
+defaultSelectSettings = SelectSettings {
+  selectSettingsDepth = Nothing
+}
 
 tagSelector :: String -> Selector
-tagSelector tag = MkSelector [toSelectNode (TagString tag) []]
+tagSelector tag = MkSelector [
+    (toSelectNode (TagString tag) [], defaultSelectSettings)
+  ]
 
 -- | A selector which will match all tags
 anySelector :: Selector
-anySelector = MkSelector [SelectAny []]
+anySelector = MkSelector [(SelectAny [], defaultSelectSettings)]
 
 instance IsString Selector where
   fromString = tagSelector

--- a/scalpel-core/tests/TestMain.hs
+++ b/scalpel-core/tests/TestMain.hs
@@ -339,6 +339,29 @@ scrapeTests = "scrapeTests" ~: TestList [
             "<a><b><c><d>1</d></b></c></a>"
             (Just ["1"])
             (texts $ "a" // "d" `atDepth` 3)
+
+    -- However, from the context of <b>, <d> is only at depth 1 because there is
+    -- no closing <c> tag within the <b> tag so the <c> tag is assumed to be
+    -- self-closing.
+    ,   scrapeTest
+            "<a><b><c><d>2</d></b></c></a>"
+            (Just ["2"])
+            (texts $ "b" // "d" `atDepth` 1)
+
+    ,   scrapeTest
+            "<a><b><c><d>2</d></b></c></a>"
+            (Just ["2"])
+            (texts $ "b" // "d")
+
+    ,   scrapeTest
+            "<b><c><d>2</d></b></c>"
+            (Just ["2"])
+            (texts $ "b" // "d")
+
+    ,   scrapeTest
+            "<b><c><d>2</d></b></c>"
+            (Just ["2"])
+            (texts $ "c" // "d")
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test

--- a/scalpel-core/tests/TestMain.hs
+++ b/scalpel-core/tests/TestMain.hs
@@ -316,6 +316,29 @@ scrapeTests = "scrapeTests" ~: TestList [
             "<a><b>1</b></a><a><b>2</b></a><a><b>3</b></a>"
             (Just ["1","2","3"])
             (texts "b")
+
+    ,   scrapeTest
+            "<a><b>1</b><c><b>2</b></c></a>"
+            (Just ["1"])
+            (texts $ "a" // "b" `atDepth` 1)
+
+    ,   scrapeTest
+            "<a><b>1</b><c><b>2</b></c></a>"
+            (Just ["2"])
+            (texts $ "a" // "b" `atDepth` 2)
+
+    ,   scrapeTest
+            "<a><b class='foo'>1</b><c><b class='foo'>2</b></c></a>"
+            (Just ["1"])
+            (texts $ "a" // "b" @: [hasClass "foo"] `atDepth` 1)
+
+    -- Depth should handle malformed HTML correctly. Below <b> and <c> are not
+    -- closed in the proper order, but since <d> is nested within both in the
+    -- context of <a>, <d> is still at depth 3.
+    ,   scrapeTest
+            "<a><b><c><d>1</d></b></c></a>"
+            (Just ["1"])
+            (texts $ "a" // "d" `atDepth` 3)
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test

--- a/scalpel/src/Text/HTML/Scalpel.hs
+++ b/scalpel/src/Text/HTML/Scalpel.hs
@@ -108,6 +108,7 @@ module Text.HTML.Scalpel (
 ,   anySelector
 -- ** Tag combinators
 ,   (//)
+,   atDepth
 -- ** Attribute predicates
 ,   (@:)
 ,   (@=)


### PR DESCRIPTION
`atDepth` allows for specifying the depth that a Selector must be at in
relation to the previous Selector or root node. For example the below
will select anchor tags that are direct children of a div tag.

```haskell
  "div" // "a" `atDepth` 1
```

Issue #21