### PR TITLE
Allow selecting bare text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   in relation to another node (#21).
 - Fix issue selecting malformed HTML where `"a" // "c"` would not match
   `<a><b><c></c></a></b>`.
+- Add `textSelector` for selecting text nodes.
 
 ## 0.5.1
 

--- a/scalpel-core/src/Text/HTML/Scalpel/Core.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Core.hs
@@ -20,6 +20,7 @@ module Text.HTML.Scalpel.Core (
 ,   tagSelector
 -- ** Wildcards
 ,   anySelector
+,   textSelector
 -- ** Tag combinators
 ,   (//)
 ,   atDepth

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Select/Types.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Select/Types.hs
@@ -14,6 +14,7 @@ module Text.HTML.Scalpel.Internal.Select.Types (
 ,   SelectNode (..)
 ,   tagSelector
 ,   anySelector
+,   textSelector
 ,   toSelectNode
 ,   SelectSettings (..)
 ,   defaultSelectSettings
@@ -80,15 +81,20 @@ tagSelector tag = MkSelector [
     (toSelectNode (TagString tag) [], defaultSelectSettings)
   ]
 
--- | A selector which will match all tags
+-- | A selector which will match any node (including tags and bare text).
 anySelector :: Selector
 anySelector = MkSelector [(SelectAny [], defaultSelectSettings)]
+
+-- | A selector which will match all text nodes.
+textSelector :: Selector
+textSelector = MkSelector [(SelectText, defaultSelectSettings)]
 
 instance IsString Selector where
   fromString = tagSelector
 
 data SelectNode = SelectNode !T.Text [AttributePredicate]
                 | SelectAny [AttributePredicate]
+                | SelectText
 
 -- | The 'TagName' type is used when creating a 'Selector' to specify the name
 -- of a tag.

--- a/scalpel-core/tests/TestMain.hs
+++ b/scalpel-core/tests/TestMain.hs
@@ -364,6 +364,21 @@ scrapeTests = "scrapeTests" ~: TestList [
             "<b><c><d>2</d></b></c>"
             (Just ["2"])
             (texts $ "c" // "d")
+
+    ,   scrapeTest
+            "1<a>2</a>3<b>4<c>5</c>6</b>7"
+            (Just $ map show [1..7])
+            (texts textSelector)
+
+    ,   scrapeTest
+            "1<a>2</a>3<b>4<c>5</c>6</b>7"
+            (Just ["1", "2", "3", "456", "7"])
+            (texts $ anySelector `atDepth` 0)
+
+    ,   scrapeTest
+            "<a><b><c><d>2</d></c></a></b>"
+            (Just ["2"])
+            (texts $ "a" // "d" `atDepth` 2)
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test

--- a/scalpel/src/Text/HTML/Scalpel.hs
+++ b/scalpel/src/Text/HTML/Scalpel.hs
@@ -94,7 +94,7 @@
 --            author   <- text       $ "span" \@: [hasClass "author"]
 --            imageURL <- 'attr' "src" $ "img"  \@: [hasClass "image"]
 --            return $ ImageComment author imageURL
--- @           
+-- @
 --
 -- Complete examples can be found in the
 -- <https://github.com/fimad/scalpel/tree/master/examples examples> folder in
@@ -108,6 +108,7 @@ module Text.HTML.Scalpel (
 ,   tagSelector
 -- ** Wildcards
 ,   anySelector
+,   textSelector
 -- ** Tag combinators
 ,   (//)
 ,   atDepth


### PR DESCRIPTION
A new selector, textSelector, is added that matches raw text nodes.
This can currently be used to capture floating text that is not directly
nested within other tags.

This is probably not super useful without the contextual awareness that
will be provided by #48.

Issue #70