### PR TITLE
Initial support for scraping multiple sub-trees

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ env:
   global:
     - ARGS="--no-terminal --install-ghc"
   matrix:
-    - RES=""                   CMD="bench scalpel-core"
-    - RES=""                   CMD="test --haddock"
-    - RES="--resolver lts-2.0" CMD="test --haddock"
-    - RES="--resolver lts-6.0" CMD="test --haddock"
+    - YAML="./stack.yaml"               CMD="bench scalpel-core"
+    - YAML="./stack.yaml"               CMD="test --haddock"
+    - YAML="./.travis/stack-lts-2.yaml" CMD="test --haddock"
+    - YAML="./.travis/stack-lts-6.yaml" CMD="test --haddock"
 
 before_install:
 # Download and unpack the stack executable
@@ -34,7 +34,7 @@ before_install:
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
 script:
-- stack $RES $ARGS $CMD
+- stack --stack-yaml $YAML $ARGS $CMD
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis/stack-lts-2.yaml
+++ b/.travis/stack-lts-2.yaml
@@ -1,0 +1,9 @@
+flags: {}
+packages:
+- ../scalpel/
+- ../scalpel-core/
+- ../examples/
+extra-deps:
+- fail-4.9.0.0
+- pointedlist-0.6.1
+resolver: lts-2.0

--- a/.travis/stack-lts-6.yaml
+++ b/.travis/stack-lts-6.yaml
@@ -1,0 +1,8 @@
+flags: {}
+packages:
+- ../scalpel/
+- ../scalpel-core/
+- ../examples/
+extra-deps:
+- fail-4.9.0.0
+resolver: lts-6.0

--- a/examples/html-to-markdown/Main.hs
+++ b/examples/html-to-markdown/Main.hs
@@ -1,0 +1,126 @@
+-- A simplistic example of how to (imperfectly) convert an HTML document into
+-- the rough markdown equivalent using serial scrapers.
+
+{-# LANGUAGE OverloadedStrings #-}
+import Control.Applicative
+import System.Environment
+import Text.HTML.Scalpel
+import Data.List
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+
+-- A data type that will hold the scraped text along with markdown relevant
+-- styling.
+data FormatedText
+    = PlainText T.Text
+    | PlainTexts [FormatedText]
+    | Header Int [FormatedText]
+    | Paragraph [FormatedText]
+    | Bold [FormatedText]
+    | Italic [FormatedText]
+    | Link T.Text [FormatedText]
+    | NewLine
+
+type Markdown = T.Text
+
+-- Escape some characters that are known to cause issues in markdown.
+escapeMd :: T.Text -> Markdown
+escapeMd = T.replace "\n" ""
+         . T.replace "\\" "\\\\"
+         . T.replace "*" "\\*"
+         . T.replace "_" "\\_"
+         . T.replace ">" "&gt;"
+
+mdFromFormatedText :: FormatedText -> Markdown
+mdFromFormatedText NewLine         = "\n\n"
+mdFromFormatedText (PlainText t)   = escapeMd $ T.strip t
+mdFromFormatedText (PlainTexts cs) = mdFromFormatedTexts cs
+mdFromFormatedText (Paragraph cs)  = mdFromFormatedTexts cs `T.append` "\n\n"
+mdFromFormatedText (Bold cs)       = decorate "**" cs
+mdFromFormatedText (Italic cs)     = decorate "*" cs
+mdFromFormatedText (Link url cs)   =
+    T.concat ["[" , mdFromFormatedTexts cs, "](", url, ")"]
+mdFromFormatedText (Header n cs)   =
+    T.concat ["\n", T.replicate n "#", " ", mdFromFormatedTexts cs, "\n\n"]
+
+mdFromFormatedTexts :: [FormatedText] -> Markdown
+mdFromFormatedTexts = T.concat . intersperse " " . map mdFromFormatedText
+
+-- Pre- and appends a textual decoration to the markdown generated from the
+-- given formated text.
+decorate :: T.Text -> [FormatedText] -> Markdown
+decorate decoration cs = T.concat [
+    decoration
+  , mdFromFormatedTexts cs
+  , decoration
+  ]
+
+formatedText :: Scraper T.Text FormatedText
+formatedText = PlainTexts <$> formatedTexts
+
+formatedTexts :: Scraper T.Text [FormatedText]
+formatedTexts = inSerial $ many $ stepNext innerScraper
+  where
+    innerScraper = formatting <|> link <|> headers <|> skip <|> unknown
+
+    formatting =   newLine <|> plainText <|> paragraph <|> bold <|> italic
+               <|> header
+    newLine    = NewLine    <$ matches ("br" `atDepth` 0)
+    plainText  = PlainText  <$> text (textSelector `atDepth` 0)
+    paragraph  = Paragraph  <$> recurseOn "p"
+    header     = Paragraph  <$> recurseOn "header"
+    bold       = Bold       <$> recurseOn "b"
+    italic     = Italic     <$> recurseOn "em"
+
+    link = chroot ("a" `atDepth` 0)
+           (Link <$> attr "href" anySelector <*> formatedTexts)
+
+    headers = h1 <|> h2 <|> h3 <|> h4 <|> h5 <|> h6
+    h1 = Header 1 <$> recurseOn "h1"
+    h2 = Header 2 <$> recurseOn "h2"
+    h3 = Header 3 <$> recurseOn "h3"
+    h4 = Header 4 <$> recurseOn "h4"
+    h5 = Header 5 <$> recurseOn "h5"
+    h6 = Header 6 <$> recurseOn "h6"
+
+    skip     = noscript <|> script <|> nav
+    script   = PlainTexts [] <$ recurseOn "script"
+    noscript = PlainTexts [] <$ recurseOn "noscript"
+    nav      = PlainTexts [] <$ recurseOn "nav"
+
+    unknown   = PlainTexts <$> recurseOn anySelector
+
+    recurseOn tag = chroot (tag `atDepth` 0) formatedTexts
+
+main :: IO ()
+main = getArgs >>= handleArgs
+
+handleArgs :: [String] -> IO ()
+handleArgs [url] = urlToMd url
+handleArgs _     = putStrLn "usage: html-to-markdown URL"
+
+urlToMd :: URL -> IO ()
+urlToMd url = do
+    c <- scrapeURL url (
+            -- Prefer to extract just the article content.
+            chroot "article" formatedText
+            -- And fall back to everything in the body otherwise.
+        <|> chroot "body" formatedText)
+    maybe printError printMd c
+    where
+        printError = putStrLn "ERROR: Could not scrape the URL!"
+        printMd    = T.putStrLn . cleanup . mdFromFormatedText
+
+        -- Cleanup some whitespace left over from converting to markdown.
+        -- TODO: Ideally this should be part of the mdFromFormatedText function.
+        cleanup = removeIndents . collapseNewLines . T.strip
+
+        removeIndents t | t == t' = t
+                        | otherwise = removeIndents t'
+          where t' = T.replace "\n " "\n" t
+
+        collapseNewLines t | t == t' = t
+                           | otherwise = collapseNewLines t'
+          where t' = T.replace "\n\n\n\n" "\n\n" t

--- a/examples/scalpel-examples.cabal
+++ b/examples/scalpel-examples.cabal
@@ -42,3 +42,12 @@ executable list-all-images
           base          >= 4.6 && < 5
       ,   scalpel       >= 0.2.0
   ghc-options: -W
+
+executable html-to-markdown
+  default-language: Haskell2010
+  main-is:          html-to-markdown/Main.hs
+  build-depends:
+          base          >= 4.6 && < 5
+      ,   text
+      ,   scalpel
+  ghc-options: -W

--- a/scalpel-core/scalpel-core.cabal
+++ b/scalpel-core/scalpel-core.cabal
@@ -36,6 +36,7 @@ library
       ,   Text.HTML.Scalpel.Internal.Select
       ,   Text.HTML.Scalpel.Internal.Select.Combinators
       ,   Text.HTML.Scalpel.Internal.Select.Types
+      ,   Text.HTML.Scalpel.Internal.Serial
   exposed-modules:
       Text.HTML.Scalpel.Core
   hs-source-dirs:   src/
@@ -46,6 +47,7 @@ library
       ,   containers
       ,   data-default
       ,   fail
+      ,   pointedlist
       ,   regex-base
       ,   regex-tdfa
       ,   tagsoup       >= 0.12.2

--- a/scalpel-core/src/Text/HTML/Scalpel/Core.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Core.hs
@@ -18,9 +18,9 @@ module Text.HTML.Scalpel.Core (
 ,   AttributeName (..)
 ,   TagName (..)
 ,   tagSelector
+,   textSelector
 -- ** Wildcards
 ,   anySelector
-,   textSelector
 -- ** Tag combinators
 ,   (//)
 ,   atDepth

--- a/scalpel-core/src/Text/HTML/Scalpel/Core.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Core.hs
@@ -46,12 +46,25 @@ module Text.HTML.Scalpel.Core (
 ,   chroot
 ,   chroots
 ,   position
+,   matches
 -- ** Executing scrapers
 ,   scrape
 ,   scrapeStringLike
+
+-- * Contextual Scraping
+,   SerialScraper
+,   visitSerially
+,   visitChildrenSerially
+,   stepBack
+,   stepNext
+,   seekBack
+,   seekNext
+,   untilBack
+,   untilNext
 ) where
 
 import Text.HTML.Scalpel.Internal.Scrape
 import Text.HTML.Scalpel.Internal.Scrape.StringLike
 import Text.HTML.Scalpel.Internal.Select.Combinators
 import Text.HTML.Scalpel.Internal.Select.Types
+import Text.HTML.Scalpel.Internal.Serial

--- a/scalpel-core/src/Text/HTML/Scalpel/Core.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Core.hs
@@ -51,15 +51,16 @@ module Text.HTML.Scalpel.Core (
 ,   scrape
 ,   scrapeStringLike
 
--- * Contextual Scraping
+-- * Serial Scraping
 ,   SerialScraper
 ,   inSerial
-,   stepBack
+-- ** Primitives
 ,   stepNext
-,   seekBack
+,   stepBack
 ,   seekNext
-,   untilBack
+,   seekBack
 ,   untilNext
+,   untilBack
 ) where
 
 import Text.HTML.Scalpel.Internal.Scrape

--- a/scalpel-core/src/Text/HTML/Scalpel/Core.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Core.hs
@@ -53,8 +53,7 @@ module Text.HTML.Scalpel.Core (
 
 -- * Contextual Scraping
 ,   SerialScraper
-,   visitSerially
-,   visitChildrenSerially
+,   inSerial
 ,   stepBack
 ,   stepNext
 ,   seekBack

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_HADDOCK hide #-}
 module Text.HTML.Scalpel.Internal.Scrape (
-    Scraper
+    Scraper (..)
 ,   scrape
 ,   attr
 ,   attrs
@@ -12,6 +12,7 @@ module Text.HTML.Scalpel.Internal.Scrape (
 ,   texts
 ,   chroot
 ,   chroots
+,   matches
 ,   position
 ) where
 
@@ -94,6 +95,11 @@ chroots :: (TagSoup.StringLike str)
         => Selector -> Scraper str a -> Scraper str [a]
 chroots selector (MkScraper inner) = MkScraper
                                    $ return . mapMaybe inner . select selector
+
+-- | The 'matches' function takes a selector and returns `()` if the selector
+-- matches any node in the DOM.
+matches :: (TagSoup.StringLike str) => Selector -> Scraper str ()
+matches s = MkScraper $ withHead (pure ()) . select s
 
 -- | The 'text' function takes a selector and returns the inner text from the
 -- set of tags described by the given selector.

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Select.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Select.hs
@@ -60,6 +60,10 @@ data SelectContext = SelectContext {
                      -- selector. This indicates the index in the result list
                      -- that this TagSpec corresponds to.
                      ctxPosition :: !Index
+                     -- | True if the current context is the result of chrooting
+                     -- to a sub-tree. This is used by serial scrapers to
+                     -- determine how to generate zippered sibling nodes.
+                   , ctxInChroot :: !Bool
                    }
 
 -- | A structured representation of the parsed tags that provides fast element
@@ -76,7 +80,7 @@ select s tagSpec = newSpecs
         (MkSelector nodes) = s
         newSpecs =
             zipWith applyPosition [0..] (selectNodes nodes tagSpec tagSpec [])
-        applyPosition p (tags, f, _) = (tags, f, SelectContext p)
+        applyPosition p (tags, f, _) = (tags, f, SelectContext p True)
 
 -- | Creates a TagSpec from a list of tags parsed by TagSoup.
 tagsToSpec :: forall str. (TagSoup.StringLike str)
@@ -85,7 +89,7 @@ tagsToSpec tags = (vector, tree, ctx)
     where
         vector = tagsToVector tags
         tree   = vectorToTree vector
-        ctx    = SelectContext 0
+        ctx    = SelectContext 0 False
 
 -- | Annotate each tag with the offset to the corresponding closing tag. This
 -- annotating is done in O(n * log(n)).

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_HADDOCK hide #-}
+module Text.HTML.Scalpel.Internal.Serial (
+    SerialScraper
+,   visitSerially
+,   visitChildrenSerially
+,   stepBack
+,   stepNext
+,   seekBack
+,   seekNext
+,   untilBack
+,   untilNext
+) where
+
+import Text.HTML.Scalpel.Internal.Scrape
+import Text.HTML.Scalpel.Internal.Select
+
+import Control.Applicative
+import Control.Monad
+import Data.List.PointedList (PointedList)
+
+import qualified Control.Monad.Fail as Fail
+import qualified Data.List.PointedList as PointedList
+import qualified Data.Tree as Tree
+import qualified Text.StringLike as TagSoup
+
+
+-- | Serial scrapers operate on a zipper of tag specs that correspond to the
+-- root nodes / siblings in a document.
+--
+-- Access to the zipper is always performed in a move-then-read manner. For this
+-- reason it is valid for the current focus of the zipper to be just off either
+-- end of list such that moving forward or backward would result in reading the
+-- first or last node.
+--
+-- These valid focuses are expressed as Nothing values at either end of the
+-- zipper since they are valid positions for the focus to pass over, but not
+-- valid positions to read.
+type SpecZipper str = PointedList (Maybe (TagSpec str))
+
+-- | A value of 'SerialScraper' @a@ is like a 'Scraper' but consumes sibling
+-- nodes in sequence.
+--
+-- A 'SerialScraper' conceptually maintains a cursor that is pointing to one of
+-- the root sibling nodes. Each serial scraper primitive moves the cursor and
+-- then extracts content using a 'Scraper'.
+newtype SerialScraper str a =
+    MkSerialScraper (SpecZipper str -> Maybe (a, SpecZipper str))
+
+instance Functor (SerialScraper str) where
+    fmap f (MkSerialScraper a) = MkSerialScraper applied
+      where applied zipper
+                | Just (aVal, zipper') <- a zipper = Just (f aVal, zipper')
+                | otherwise                        = Nothing
+
+instance Applicative (SerialScraper str) where
+    pure a = MkSerialScraper $ \zipper -> Just (a, zipper)
+    (MkSerialScraper f) <*> (MkSerialScraper a) = MkSerialScraper applied
+        where
+          applied zipper = do
+              (f', zipper')  <- f zipper
+              (a', zipper'') <- a zipper'
+              return (f' a', zipper'')
+
+instance Alternative (SerialScraper str) where
+    empty = MkSerialScraper $ const Nothing
+    (MkSerialScraper a) <|> (MkSerialScraper b) = MkSerialScraper choice
+        where choice zipper | (Just aVal) <- a zipper = Just aVal
+                            | otherwise               = b zipper
+
+instance Monad (SerialScraper str) where
+    fail = Fail.fail
+    return = pure
+    (MkSerialScraper a) >>= f = MkSerialScraper combined
+        where
+          combined zipper = do
+              (aVal, zipper') <- a zipper
+              let (MkSerialScraper b) = f aVal
+              b zipper'
+
+instance MonadPlus (SerialScraper str) where
+    mzero = empty
+    mplus = (<|>)
+
+instance Fail.MonadFail (SerialScraper str) where
+    fail _ = mzero
+
+-- | Executes a 'SerialScraper' in the context of a 'Scraper'. The focused nodes
+-- are visited serially.
+visitSerially :: TagSoup.StringLike str => SerialScraper str a -> Scraper str a
+visitSerially (MkSerialScraper serialScraper) = MkScraper scraper
+  where
+    scraper spec = fst <$> serialScraper (toZipper spec)
+
+    -- Create a zipper from the current tag spec by generating a new tag spec
+    -- that just contains each root node in the forest.
+    toZipper (vector, forest, context) =
+        zipperFromList $ map ((vector, , context) . return) forest
+
+-- | Executes a 'SerialScraper' in the context of a 'Scraper', the children of
+-- the focused node are visited serially.
+visitChildrenSerially :: TagSoup.StringLike str
+                      => SerialScraper str a -> Scraper str a
+visitChildrenSerially serialScraper = MkScraper scraper
+  where
+    (MkScraper childScraper) = visitSerially serialScraper
+    scraper (_, [], _)           = Nothing
+    scraper (vec, root : _, ctx) = childScraper (vec, Tree.subForest root, ctx)
+
+-- | Creates a SpecZipper from a list of tag specs. This requires bookending the
+-- zipper with Nothing values to denote valid focuses that are just off either
+-- end of the list.
+zipperFromList :: TagSoup.StringLike str => [TagSpec str] -> SpecZipper str
+zipperFromList = PointedList.insertLeft Nothing
+               . foldr (PointedList.insertLeft . Just)
+                       (PointedList.singleton Nothing)
+
+stepWith :: TagSoup.StringLike str
+         => (SpecZipper str -> Maybe (SpecZipper str))
+         -> Scraper str b
+         -> SerialScraper str b
+stepWith moveList (MkScraper scraper) = MkSerialScraper $ \zipper -> do
+    zipper' <- moveList zipper
+    focus <- PointedList._focus zipper'
+    value <- scraper focus
+    return (value, zipper')
+
+-- | Move the cursor back one node and execute the given scraper on the new
+-- focused node.
+stepBack :: TagSoup.StringLike str => Scraper str a -> SerialScraper str a
+stepBack = stepWith PointedList.previous
+
+-- | Move the cursor forward one node and execute the given scraper on the new
+-- focused node.
+stepNext :: TagSoup.StringLike str => Scraper str a -> SerialScraper str a
+stepNext = stepWith PointedList.next
+
+seekWith :: TagSoup.StringLike str
+         => (SpecZipper str -> Maybe (SpecZipper str))
+         -> Scraper str b
+         -> SerialScraper str b
+seekWith moveList (MkScraper scraper) = MkSerialScraper go
+    where
+      go zipper = do
+        zipper' <- moveList zipper
+        runScraper zipper' <|> go zipper'
+      runScraper zipper = do
+        focus <- PointedList._focus zipper
+        value <- scraper focus
+        return (value, zipper)
+
+-- | Move the cursor backward until the given scraper is successfully able to
+-- execute on the focused node. If the scraper is never successful then the
+-- serial scraper will fail.
+seekBack :: TagSoup.StringLike str => Scraper str a -> SerialScraper str a
+seekBack = seekWith PointedList.previous
+
+-- | Move the cursor forward until the given scraper is successfully able to
+-- execute on the focused node. If the scraper is never successful then the
+-- serial scraper will fail.
+seekNext :: TagSoup.StringLike str => Scraper str a -> SerialScraper str a
+seekNext = seekWith PointedList.next
+
+untilWith :: TagSoup.StringLike str
+         => (SpecZipper str -> Maybe (SpecZipper str))
+         -> (Maybe (TagSpec str) -> SpecZipper str -> SpecZipper str)
+         -> Scraper str a
+         -> SerialScraper str b
+         -> SerialScraper str b
+untilWith moveList appendNode
+          (MkScraper untilScraper) (MkSerialScraper scraper) =
+  MkSerialScraper $ \zipper -> do
+      let (innerZipper, zipper') = split zipper
+      (value, _)  <- scraper $ appendNode Nothing innerZipper
+      return (value, zipper')
+  where
+    split zipper
+        | Just zipper' <- moveList zipper
+        , Just spec    <- PointedList._focus zipper'
+        , Nothing <- untilScraper spec =
+            let (specs, zipper'') = split zipper'
+            in  (appendNode (Just spec) specs, zipper'')
+        | otherwise                   = (PointedList.singleton Nothing, zipper)
+
+-- | Create a new serial context by moving the focus backward and collecting
+-- nodes until the scraper matches the focused node. The serial scraper is then
+-- executed on the collected nodes.
+untilBack :: TagSoup.StringLike str
+          => Scraper str a -> SerialScraper str b -> SerialScraper str b
+untilBack = untilWith PointedList.previous PointedList.insertRight
+
+-- | Create a new serial context by moving the focus forward and collecting
+-- nodes until the scraper matches the focused node. The serial scraper is then
+-- executed on the collected nodes.
+untilNext :: TagSoup.StringLike str
+          => Scraper str a -> SerialScraper str b -> SerialScraper str b
+untilNext = untilWith PointedList.next PointedList.insertLeft

--- a/scalpel-core/tests/TestMain.hs
+++ b/scalpel-core/tests/TestMain.hs
@@ -379,6 +379,159 @@ scrapeTests = "scrapeTests" ~: TestList [
             "<a><b><c><d>2</d></c></a></b>"
             (Just ["2"])
             (texts $ "a" // "d" `atDepth` 2)
+
+    ,   scrapeTest
+            "<a>1</a><b>2</b><a>3</a>"
+            (Just ("1", "2"))
+            (visitSerially $ (,) <$> stepNext (text "a")
+                          <*> stepNext (text "b"))
+
+    ,   scrapeTest
+            "<a>1</a><b>2</b><a>3</a>"
+            (Just ("1", "2"))
+            (visitSerially $ do
+              a <- stepNext (text "a")
+              b <- stepNext (text "b")
+              return (a, b))
+
+    ,   scrapeTest
+            "<a>1</a><b>2</b><a>3</a>"
+            (Just ["1", "2", "3", "2" , "1"])
+            (visitSerially $ do
+              a <- stepNext $ text anySelector
+              b <- stepNext $ text anySelector
+              c <- stepNext $ text anySelector
+              d <- stepBack $ text anySelector
+              e <- stepBack $ text anySelector
+              return [a, b, c, d, e])
+
+    ,   scrapeTest
+            "<a>1</a><b>2</b><a>3</a>"
+            Nothing
+            (visitSerially $ (,,,) <$> stepNext (text anySelector)
+                            <*> stepNext (text anySelector)
+                            <*> stepNext (text anySelector)
+                            <*> stepNext (text anySelector))
+
+    ,   scrapeTest
+            "<a>1</a><b>2</b><a>3</a>"
+            (Just ("2", "3"))
+            (visitSerially $ (,) <$> seekNext (text "b")
+                          <*> seekNext (text "a"))
+
+    ,   scrapeTest
+            "<a>1</a><b>2</b><a>3</a>"
+            Nothing
+            (visitSerially $ seekNext $ text "c")
+
+    ,   scrapeTest
+            "<a>1</a><b>2</b><c>3</c>"
+            (Just ("3", "1"))
+            (visitSerially $ (,) <$> seekNext (text "c")
+                          <*> seekBack (text "a"))
+
+    ,   scrapeTest
+            "1<a foo=bar>2</a>3"
+            (Just ["1", "bar", "3"])
+            (visitSerially $   many
+                           $   stepNext (text $ textSelector `atDepth` 0)
+                           <|> stepNext (attr "foo" $ "a" `atDepth` 0))
+
+    ,   scrapeTest
+            "1"
+            (Just "OK")
+            (visitSerially $ do
+              "1" <- stepNext $ text textSelector
+              return "OK")
+
+    ,   scrapeTest
+            "1"
+            Nothing
+            (visitSerially $ do
+              "mismatch" <- stepNext $ text textSelector
+              return "OK")
+
+    ,   scrapeTest
+            "1<a>2</a><b>3</b>"
+            (Just ["1", "2"])
+            (visitSerially $ untilNext (matches "b")
+                           $ many $ stepNext $ text anySelector)
+
+    ,   scrapeTest
+            "1<a>2</a><b>3</b>"
+            (Just ["1", "2", "3"])
+            (visitSerially $ untilNext (matches "c")
+                           $ many $ stepNext $ text anySelector)
+
+    ,   scrapeTest
+            "1<a>2</a><b>3</b>"
+            (Just "3")
+            (visitSerially $ do
+              untilNext (matches "b") $ many $ stepNext $ text anySelector
+              stepNext $ text "b")
+
+    ,   scrapeTest
+            "<a>1</a><a>2</a>"
+            (Just "1")
+            (visitSerially $ do
+              untilNext (matches "a") $ return ()
+              stepNext $ text "a")
+
+    ,   scrapeTest
+            "<a>1</a><a>2</a>"
+            Nothing
+            (visitSerially $ do
+              untilNext (matches "a") $ stepNext $ text anySelector
+              stepNext $ text "a")
+
+    ,   scrapeTest
+            "<b foo=bar /><a>1</a><a>2</a><a>3</a>"
+            (Just ("bar", ["1", "2", "3"], ["2", "1"]))
+            (visitSerially $ do
+              as <- many $ seekNext $ text "a"
+              as' <- untilBack (matches "b") $ many $ stepBack $ text "a"
+              b <- stepBack $ attr "foo" "b"
+              return (b, as, as'))
+
+    ,   scrapeTest
+            "<parent><a>1</a><b>2</b></parent>"
+            (Just ["1", "2"])
+            (chroot "parent" $ visitChildrenSerially $
+              many $ stepNext $ text anySelector)
+
+    -- Issue #41
+    ,   scrapeTest
+            "<p class='something'>Here</p><p>Other stuff that matters</p>"
+            (Just "Other stuff that matters")
+            (visitSerially $ do
+              seekNext $ matches $ "p" @: [hasClass "something"]
+              stepNext $ text "p")
+
+    -- Issue #45
+    ,   scrapeTest
+            (unlines [
+              "<body>"
+            , "  <h1>title1</h1>"
+            , "  <h2>title2 1</h2>"
+            , "  <p>text 1</p>"
+            , "  <p>text 2</p>"
+            , "  <h2>title2 2</h2>"
+            , "  <p>text 3</p>"
+            , "  <h2>title2 3</h2>"
+            , "</body>"
+            ])
+            (Just [
+              ("title2 1", ["text 1", "text 2"])
+            , ("title2 2", ["text 3"])
+            , ("title2 3", [])
+            ])
+            (chroot "body" $ visitChildrenSerially $ many $ do
+                title <- seekNext $ text "h2"
+                -- TODO: seekNext must be used instead of stepNext because there
+                -- are now text nodes that have been inserted between the p
+                -- nodes that fail the match against "p".
+                ps <- untilNext (matches "h2") (many $ seekNext $ text "p")
+                return (title, ps))
     ]
 
 scrapeTest :: (Eq a, Show a) => String -> Maybe a -> Scraper String a -> Test

--- a/scalpel/src/Text/HTML/Scalpel.hs
+++ b/scalpel/src/Text/HTML/Scalpel.hs
@@ -148,15 +148,16 @@ module Text.HTML.Scalpel (
 ,   utf8Decoder
 ,   iso88591Decoder
 
--- * Contextual Scraping
+-- * Serial Scraping
 ,   SerialScraper
 ,   inSerial
-,   stepBack
+-- ** Primitives
 ,   stepNext
-,   seekBack
+,   stepBack
 ,   seekNext
-,   untilBack
+,   seekBack
 ,   untilNext
+,   untilBack
 ) where
 
 import Text.HTML.Scalpel.Core

--- a/scalpel/src/Text/HTML/Scalpel.hs
+++ b/scalpel/src/Text/HTML/Scalpel.hs
@@ -150,8 +150,7 @@ module Text.HTML.Scalpel (
 
 -- * Contextual Scraping
 ,   SerialScraper
-,   visitSerially
-,   visitChildrenSerially
+,   inSerial
 ,   stepBack
 ,   stepNext
 ,   seekBack

--- a/scalpel/src/Text/HTML/Scalpel.hs
+++ b/scalpel/src/Text/HTML/Scalpel.hs
@@ -134,6 +134,7 @@ module Text.HTML.Scalpel (
 ,   chroot
 ,   chroots
 ,   position
+,   matches
 -- ** Executing scrapers
 ,   scrape
 ,   scrapeStringLike
@@ -146,6 +147,17 @@ module Text.HTML.Scalpel (
 ,   defaultDecoder
 ,   utf8Decoder
 ,   iso88591Decoder
+
+-- * Contextual Scraping
+,   SerialScraper
+,   visitSerially
+,   visitChildrenSerially
+,   stepBack
+,   stepNext
+,   seekBack
+,   seekNext
+,   untilBack
+,   untilNext
 ) where
 
 import Text.HTML.Scalpel.Core

--- a/scalpel/src/Text/HTML/Scalpel.hs
+++ b/scalpel/src/Text/HTML/Scalpel.hs
@@ -106,9 +106,9 @@ module Text.HTML.Scalpel (
 ,   AttributeName (..)
 ,   TagName (..)
 ,   tagSelector
+,   textSelector
 -- ** Wildcards
 ,   anySelector
-,   textSelector
 -- ** Tag combinators
 ,   (//)
 ,   atDepth


### PR DESCRIPTION
The approach utilizes a zipper like API to focus on sibling nodes and
execute scrapers on the focused nodes. Regression tests have been added
that shows that this solves the requirements in issues #41, and #45.

Issue #48