### PR TITLE
Remove dependency on curl

### DIFF
--- a/.travis/stack-lts-2.yaml
+++ b/.travis/stack-lts-2.yaml
@@ -5,5 +5,7 @@ packages:
 - ../examples/
 extra-deps:
 - fail-4.9.0.0
+- http-client-0.4.30
+- http-client-tls-0.2.4
 - pointedlist-0.6.1
 resolver: lts-2.0

--- a/.travis/stack-lts-6.yaml
+++ b/.travis/stack-lts-6.yaml
@@ -5,4 +5,5 @@ packages:
 - ../examples/
 extra-deps:
 - fail-4.9.0.0
+- http-client-0.4.30
 resolver: lts-6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## HEAD
 
+### Breaking Changes
+
+- The dependency on `curl` has been replaced with `http-client` and
+  `http-client-tls`. This has the following observable changes.
+  - `scrapeURLWithOpts` is removed.
+  - The `Config` type used with `scrapeURLWithConfig` no longer contains a list
+    of curl options. Instead it now takes a `Maybe Manager` from `http-client`.
+  - The `Decoder` function type now takes in a `Response` type from
+    `http-client`.
+  - `scrapeURL` will now throw an exception if there is a problem connecting to
+     a URL.
+
+### Other Changes
+
 - Remove `Ord` constraint from public APIs.
 - Add `atDepth` operator which allows for selecting nodes at a specified depth
   in relation to another node (#21).

--- a/examples/custom-user-agent/Main.hs
+++ b/examples/custom-user-agent/Main.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import System.Environment
+import Text.HTML.Scalpel
+import Data.Default (def)
+
+import qualified Network.HTTP.Client as HTTP
+import qualified Network.HTTP.Client.TLS as HTTP
+import qualified Network.HTTP.Types.Header as HTTP
+
+
+-- Create a new manager settings based on the default TLS manager that updates
+-- the request headers to include a custom user agent.
+managerSettings :: HTTP.ManagerSettings
+managerSettings = HTTP.tlsManagerSettings {
+  HTTP.managerModifyRequest = \req -> do
+    req' <- HTTP.managerModifyRequest HTTP.tlsManagerSettings req
+    return $ req' {
+      HTTP.requestHeaders = (HTTP.hUserAgent, "My Custom UA")
+                          : HTTP.requestHeaders req'
+    }
+}
+
+main :: IO ()
+main = getArgs >>= handleArgs
+
+handleArgs :: [String] -> IO ()
+handleArgs [url] = listUrlsForSite url
+handleArgs _     = putStrLn "usage: custom-user-agent URL"
+
+listUrlsForSite :: URL -> IO ()
+listUrlsForSite url = do
+    manager <- Just <$> HTTP.newManager managerSettings
+    images <- scrapeURLWithConfig (def { manager }) url (attrs "src" "img")
+    maybe printError printImages images
+    where
+        printError = putStrLn "ERROR: Could not scrape the URL!"
+        printImages = mapM_ putStrLn

--- a/examples/custom-user-agent/Main.hs
+++ b/examples/custom-user-agent/Main.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
+import Control.Applicative ((<$>))
+import Data.Default (def)
 import System.Environment
 import Text.HTML.Scalpel
-import Data.Default (def)
 
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Client.TLS as HTTP

--- a/examples/scalpel-examples.cabal
+++ b/examples/scalpel-examples.cabal
@@ -42,3 +42,15 @@ executable list-all-images
           base          >= 4.6 && < 5
       ,   scalpel       >= 0.2.0
   ghc-options: -W
+
+executable custom-user-agent
+  default-language: Haskell2010
+  main-is:          custom-user-agent/Main.hs
+  build-depends:
+          base          >= 4.6 && < 5
+      ,   data-default
+      ,   http-client
+      ,   http-client-tls
+      ,   http-types
+      ,   scalpel
+  ghc-options: -W

--- a/scalpel/scalpel.cabal
+++ b/scalpel/scalpel.cabal
@@ -40,8 +40,10 @@ library
           base          >= 4.6 && < 5
       ,   scalpel-core  == 0.5.1
       ,   bytestring
-      ,   curl          >= 1.3.4
+      ,   case-insensitive
       ,   data-default
+      ,   http-client
+      ,   http-client-tls
       ,   tagsoup       >= 0.12.2
       ,   text
   default-extensions:

--- a/scalpel/scalpel.cabal
+++ b/scalpel/scalpel.cabal
@@ -37,14 +37,14 @@ library
   hs-source-dirs:   src/
   default-language: Haskell2010
   build-depends:
-          base          >= 4.6 && < 5
-      ,   scalpel-core  == 0.5.1
+          base            >= 4.6 && < 5
+      ,   scalpel-core    == 0.5.1
       ,   bytestring
       ,   case-insensitive
       ,   data-default
-      ,   http-client
-      ,   http-client-tls
-      ,   tagsoup       >= 0.12.2
+      ,   http-client     >= 0.4.30
+      ,   http-client-tls >= 0.2.4
+      ,   tagsoup         >= 0.12.2
       ,   text
   default-extensions:
           ParallelListComp

--- a/scalpel/src/Text/HTML/Scalpel.hs
+++ b/scalpel/src/Text/HTML/Scalpel.hs
@@ -139,7 +139,6 @@ module Text.HTML.Scalpel (
 ,   scrapeStringLike
 ,   URL
 ,   scrapeURL
-,   scrapeURLWithOpts
 ,   scrapeURLWithConfig
 ,   Config (..)
 ,   Decoder

--- a/scalpel/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
+++ b/scalpel/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Text.HTML.Scalpel.Internal.Scrape.URL (
     URL
@@ -9,88 +10,68 @@ module Text.HTML.Scalpel.Internal.Scrape.URL (
 ,   iso88591Decoder
 
 ,   scrapeURL
-,   scrapeURLWithOpts
 ,   scrapeURLWithConfig
 ) where
 
 import Text.HTML.Scalpel.Core
 
 import Control.Applicative ((<$>))
-import Data.Char (toLower)
+import Data.CaseInsensitive ()
 import Data.Default (def)
-import Data.List (isInfixOf)
-import Data.Maybe (listToMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 
-import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Default as Default
+import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import qualified Network.Curl as Curl
+import qualified Network.HTTP.Client as HTTP
+import qualified Network.HTTP.Client.TLS as HTTP
 import qualified Text.HTML.TagSoup as TagSoup
 import qualified Text.StringLike as TagSoup
 
 
 type URL = String
 
-type CurlResponse = Curl.CurlResponse_ [(String, String)] BS.ByteString
-
 -- | A method that takes a HTTP response as raw bytes and returns the body as a
 -- string type.
-type Decoder str = Curl.CurlResponse_ [(String, String)] BS.ByteString -> str
+type Decoder str = HTTP.Response LBS.ByteString -> str
 
 -- | A record type that determines how 'scrapeUrlWithConfig' interacts with the
 -- HTTP server and interprets the results.
 data Config str = Config {
-    curlOpts :: [Curl.CurlOption]
-,   decoder  :: Decoder str
+    decoder :: Decoder str
+,   manager :: Maybe HTTP.Manager
 }
 
 instance TagSoup.StringLike str => Default.Default (Config str) where
     def = Config {
-            curlOpts = [Curl.CurlFollowLocation True]
-        ,   decoder  = defaultDecoder
+            decoder = defaultDecoder
+        ,   manager = Nothing
         }
 
 -- | The 'scrapeURL' function downloads the contents of the given URL and
 -- executes a 'Scraper' on it.
 --
--- 'scrapeURL' makes use of curl to make HTTP requests. The dependency on curl
--- may be too heavyweight for some use cases. In which case users who do not
--- require inbuilt networking support can depend on
--- <https://hackage.haskell.org/package/scalpel-core scalpel-core> for a
--- lightweight subset of this library that does not depend on curl.
+-- The default behavior is to use the global manager provided by
+-- http-client-tls (via 'HTTP.getGlobalManager'). Any exceptions thrown by
+-- http-client are not caught and are bubbled up to the caller.
 scrapeURL :: (TagSoup.StringLike str)
           => URL -> Scraper str a -> IO (Maybe a)
-scrapeURL = scrapeURLWithOpts [Curl.CurlFollowLocation True]
-
--- | The 'scrapeURLWithOpts' function take a list of curl options and downloads
--- the contents of the given URL and executes a 'Scraper' on it.
-scrapeURLWithOpts :: (TagSoup.StringLike str)
-                  => [Curl.CurlOption] -> URL -> Scraper str a -> IO (Maybe a)
-scrapeURLWithOpts options = scrapeURLWithConfig (def {curlOpts = options})
+scrapeURL = scrapeURLWithConfig def
 
 -- | The 'scrapeURLWithConfig' function takes a 'Config' record type and
 -- downloads the contents of the given URL and executes a 'Scraper' on it.
 scrapeURLWithConfig :: (TagSoup.StringLike str)
                   => Config str -> URL -> Scraper str a -> IO (Maybe a)
 scrapeURLWithConfig config url scraper = do
-    maybeTags <- downloadAsTags (decoder config) url
-    return (maybeTags >>= scrape scraper)
+    manager <- fromMaybe HTTP.getGlobalManager (return <$> manager config)
+    tags <- downloadAsTags (decoder config) manager url
+    return (scrape scraper tags)
     where
-        downloadAsTags decoder url = do
-            maybeBytes <- openURIWithOpts url (curlOpts config)
-            return $ TagSoup.parseTags . decoder <$> maybeBytes
-
-openURIWithOpts :: URL -> [Curl.CurlOption] -> IO (Maybe CurlResponse)
-openURIWithOpts url opts = do
-    resp <- curlGetResponse_ url opts
-    return $ if Curl.respCurlCode resp /= Curl.CurlOK
-        then Nothing
-        else Just resp
-
-curlGetResponse_ :: URL
-                 -> [Curl.CurlOption]
-                 -> IO (Curl.CurlResponse_ [(String, String)] BS.ByteString)
-curlGetResponse_ = Curl.curlGetResponse_
+        downloadAsTags decoder manager url = do
+            request <- HTTP.parseRequest url
+            response <- HTTP.httpLbs request manager
+            return $ TagSoup.parseTags $ decoder response
 
 -- | The default response decoder. This decoder attempts to infer the character
 -- set of the HTTP response body from the `Content-Type` header. If this header
@@ -99,24 +80,24 @@ defaultDecoder :: TagSoup.StringLike str => Decoder str
 defaultDecoder response = TagSoup.castString
                         $ choosenDecoder body
     where
-        body        = Curl.respBody response
-        headers     = Curl.respHeaders response
+        body        = HTTP.responseBody response
+        headers     = HTTP.responseHeaders response
         contentType = listToMaybe
-                    $ map (map toLower . snd)
+                    $ map (Text.decodeLatin1 . snd)
                     $ take 1
-                    $ dropWhile ((/= "content-type") . map toLower . fst)
+                    $ dropWhile ((/= "content-type") . fst)
                                 headers
 
-        isType t | Just ct <- contentType = ("charset=" ++ t) `isInfixOf` ct
+        isType t | Just ct <- contentType = ("charset=" `Text.append` t) `Text.isInfixOf` ct
                  | otherwise              = False
 
-        choosenDecoder | isType "utf-8" = Text.decodeUtf8
-                       | otherwise      = Text.decodeLatin1
+        choosenDecoder | isType "utf-8" = Text.decodeUtf8 . LBS.toStrict
+                       | otherwise      = Text.decodeLatin1 . LBS.toStrict
 
 -- | A decoder that will always decode using `UTF-8`.
 utf8Decoder ::  TagSoup.StringLike str => Decoder str
-utf8Decoder = TagSoup.castString . Text.decodeUtf8 . Curl.respBody
+utf8Decoder = TagSoup.castString . Text.decodeUtf8 . LBS.toStrict . HTTP.responseBody
 
 -- | A decoder that will always decode using `ISO-8859-1`.
 iso88591Decoder ::  TagSoup.StringLike str => Decoder str
-iso88591Decoder = TagSoup.castString . Text.decodeLatin1 . Curl.respBody
+iso88591Decoder = TagSoup.castString . Text.decodeLatin1 . LBS.toStrict . HTTP.responseBody


### PR DESCRIPTION
This replaces 'curl' with 'http-client'/'http-client-tls' and updates
the related 'scrapeURL*' APIs accordingly.

In addition to the obvious API changes there is the additional behavior
change where scrapeURL now throws an exception if there is a networking
error instead of returning Nothing. This makes HTML scraping errors
distinguishable from networking issues.

Issue #58