### PR TITLE
Support GHC 8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - YAML="./.travis/stack-lts-2.yaml" CMD="test --haddock"
     - YAML="./.travis/stack-lts-6.yaml" CMD="test --haddock"
     - YAML="./.travis/stack-lts-7.yaml" CMD="test --haddock"
+    - YAML="./.travis/stack-lts-20190117.yaml" CMD="test --haddock"
 
 before_install:
 # Download and unpack the stack executable

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ env:
   matrix:
     - YAML="./stack.yaml"               CMD="bench scalpel-core"
     - YAML="./stack.yaml"               CMD="test --haddock"
-    - YAML="./.travis/stack-lts-2.yaml" CMD="test --haddock"
+    - YAML="./.travis/stack-lts-3.yaml" CMD="test --haddock"
     - YAML="./.travis/stack-lts-6.yaml" CMD="test --haddock"
     - YAML="./.travis/stack-lts-7.yaml" CMD="test --haddock"
-    - YAML="./.travis/stack-lts-20190117.yaml" CMD="test --haddock"
+    - YAML="./.travis/stack-nightly-20190117.yaml" CMD="test --haddock"
 
 before_install:
 # Download and unpack the stack executable

--- a/.travis/stack-lts-20190117.yaml
+++ b/.travis/stack-lts-20190117.yaml
@@ -1,6 +1,0 @@
-flags: {}
-packages:
-- ../scalpel/
-- ../scalpel-core/
-- ../examples/
-resolver: nightly-2020-01-17

--- a/.travis/stack-lts-20190117.yaml
+++ b/.travis/stack-lts-20190117.yaml
@@ -1,6 +1,6 @@
 flags: {}
 packages:
-- scalpel/
-- scalpel-core/
-- examples/
+- ../scalpel/
+- ../scalpel-core/
+- ../examples/
 resolver: nightly-2020-01-17

--- a/.travis/stack-lts-20190117.yaml
+++ b/.travis/stack-lts-20190117.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- scalpel/
+- scalpel-core/
+- examples/
+resolver: nightly-2020-01-17

--- a/.travis/stack-lts-3.yaml
+++ b/.travis/stack-lts-3.yaml
@@ -8,4 +8,4 @@ extra-deps:
 - http-client-0.4.30
 - http-client-tls-0.2.4
 - pointedlist-0.6.1
-resolver: lts-2.0
+resolver: lts-3.0

--- a/.travis/stack-nightly-20190117.yaml
+++ b/.travis/stack-nightly-20190117.yaml
@@ -1,6 +1,6 @@
 flags: {}
 packages:
-- scalpel/
-- scalpel-core/
-- examples/
+- ../scalpel/
+- ../scalpel-core/
+- ../examples/
 resolver: nightly-2020-01-17

--- a/.travis/stack-nightly-20190117.yaml
+++ b/.travis/stack-nightly-20190117.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- scalpel/
+- scalpel-core/
+- examples/
+resolver: nightly-2020-01-17

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Text.HTML.Scalpel.Internal.Scrape (
     Scraper (..)
@@ -51,7 +52,9 @@ instance Alternative (Scraper str) where
                           | otherwise             = b tags
 
 instance Monad (Scraper str) where
+#if __GLASGOW_HASKELL__ < 808
     fail = Fail.fail
+#endif
     return = pure
     (MkScraper a) >>= f = MkScraper combined
         where combined tags | (Just aVal) <- a tags = let (MkScraper b) = f aVal

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Text.HTML.Scalpel.Internal.Serial (
@@ -116,7 +117,9 @@ instance Alternative (SerialScraper str) where
                             | otherwise               = b zipper
 
 instance Monad (SerialScraper str) where
+#if __GLASGOW_HASKELL__ < 808
     fail = Fail.fail
+#endif
     return = pure
     (MkSerialScraper a) >>= f = MkSerialScraper combined
         where


### PR DESCRIPTION
Scalpel is currently disabled from stackage, with this change scalpel
will build with the latest stackage nightly.

Issue #85