### PR TITLE
Match Content-Type case-insensitively

### DIFF
--- a/scalpel/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
+++ b/scalpel/src/Text/HTML/Scalpel/Internal/Scrape/URL.hs
@@ -91,7 +91,7 @@ defaultDecoder response = TagSoup.castString
         body        = HTTP.responseBody response
         headers     = HTTP.responseHeaders response
         contentType = listToMaybe
-                    $ map (Text.decodeLatin1 . snd)
+                    $ map (Text.toLower . Text.decodeLatin1 . snd)
                     $ take 1
                     $ dropWhile ((/= "content-type") . fst)
                                 headers


### PR DESCRIPTION
e.g. Wikipedia gives `UTF-8`, not `utf-8`