### PR TITLE
Adapt to removal of re-exports in mtl-2.3

### DIFF
--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Scrape.hs
@@ -36,6 +36,7 @@ import Control.Monad.Reader
 import Control.Monad.State (MonadState)
 import Control.Monad.Trans.Maybe
 import Control.Monad.Writer (MonadWriter)
+import Control.Monad.Fix
 import Data.Functor.Identity
 import Data.Maybe
 

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
@@ -31,6 +31,7 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Trans.Maybe
 import Control.Monad.Writer (MonadWriter)
+import Control.Monad.Fix
 import Data.Bifunctor
 import Data.Functor.Identity
 import Data.List.PointedList (PointedList)


### PR DESCRIPTION
I've tested that it builds and that the test suite passes