### PR TITLE
Fix markup: escape /'s

### DIFF
--- a/scalpel/src/Text/HTML/Scalpel.hs
+++ b/scalpel/src/Text/HTML/Scalpel.hs
@@ -41,7 +41,7 @@
 --
 -- The following is an example that demonstrates most of the features provided
 -- by this library. Suppose you have the following hypothetical HTML located at
--- @\"http://example.com/article.html\"@ and you would like to extract a list of
+-- @\"http:\/\/example.com\/article.html\"@ and you would like to extract a list of
 -- all of the comments.
 --
 -- > <html>


### PR DESCRIPTION
`/` is used for italics in Haddock.

Currently the docs are rendered this way:

![obraz](https://github.com/user-attachments/assets/cffa581b-001a-49b3-957c-8cc71c9dc630)

I didn't try building the docs after introducing the fix. However, I tried it in the [Haddock Dingus ](https://haddock-dingus.fly.dev/inputs/2374d82631404947) and it looks ok.