### PR TITLE
SerialScraper: Skip a child example, tests for examples

### DIFF
--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
@@ -111,6 +111,40 @@ type SpecZipper str = PointedList (Maybe (TagSpec str))
 --    ("Section 2", ["Paragraph 2.1", "Paragraph 2.2"]),
 --  ])
 -- @
+--
+-- Note that the iteration happens specifically over /siblings/. Any nested
+-- tags are processed as part of the node that holds them. For example, given
+-- the following HTML:
+--
+-- @
+--  \<article\>
+--    \<h1\>Title\</h1\>
+--    \<p\>Paragraph 1
+--      \<p\>Paragraph 1.1\</p\>
+--    \</p\>
+--    \<p\>Paragraph 2\</p\>
+--  \</article\>
+-- @
+--
+-- Processed like this:
+--
+-- @
+-- 'chroot' "article" $ 'inSerial' $ do
+--     title <- 'seekNext' $ 'text' "h1"
+--     p1 <- 'seekNext' $ 'text' "p"
+--     p2 <- 'seekNext' $ 'text' "p"
+--     return (title, p1, p2)
+-- @
+--
+-- Which will evaluate to:
+--
+-- @
+--  (\"Title", "Paragraph 1\\n    Paragraph 1.1\\n  ", "Paragraph 2")
+-- @
+--
+-- Notice how both "Paragraph 1" and "Paragraph 1.1" text was extracted by the
+-- first paragraph scraper. The newlines and the spaces are coming from text
+-- nodes between the tags.
 type SerialScraper str a = SerialScraperT str Identity a
 
 -- | Run a serial scraper transforming over a monad 'm'.

--- a/scalpel-core/tests/TestMain.hs
+++ b/scalpel-core/tests/TestMain.hs
@@ -617,6 +617,53 @@ scrapeTests = "scrapeTests" ~: TestList [
                   optional $ stepNext $ matches textSelector
                   stepNext $ text "p")
                 return (title, ps))
+
+    ,   scrapeTest
+            "Haddock example for inSerial: First example"
+            (unlines [
+              "<article>"
+            , "  <h1>title</h1>"
+            , "  <h2>Section 1</h2>"
+            , "  <p>Paragraph 1.1</p>"
+            , "  <p>Paragraph 1.2</p>"
+            , "  <h2>Section 2</h2>"
+            , "  <p>Paragraph 2.1</p>"
+            , "  <p>Paragraph 2.2</p>"
+            , "</article>"
+            ])
+            (Just ("title", [
+                ("Section 1", ["Paragraph 1.1", "Paragraph 1.2"])
+              , ("Section 2", ["Paragraph 2.1", "Paragraph 2.2"])
+            ]))
+            (chroot "article" $ inSerial $ do
+                title <- seekNext $ text "h1"
+                sections <- many $ do
+                   section <- seekNext $ text "h2"
+                   ps <- untilNext (matches "h2") (many $ seekNext $ text "p")
+                   return (section, ps)
+                return (title, sections))
+
+    ,   scrapeTest
+            "Haddock example for inSerial: Second example"
+            (unlines [
+              "<article>"
+            , "  <h1>Title</h1>"
+            , "  <p>Paragraph 1"
+            , "    <p>Paragraph 1.1</p>"
+            , "  </p>"
+            , "  <p>Paragraph 2</p>"
+            , "</article>"
+            ])
+            (Just (
+                "Title"
+              , "Paragraph 1\n    Paragraph 1.1\n  "
+              , "Paragraph 2"
+            ))
+            (chroot "article" $ inSerial $ do
+                title <- seekNext $ text "h1"
+                p1 <- seekNext $ text "p"
+                p2 <- seekNext $ text "p"
+                return (title, p1, p2))
     ]
 
 scrapeTest :: (Eq a, Show a)


### PR DESCRIPTION
While documentation for `SerialScraper` already says that the iteration happens over siblings, I actually missed that part initially.  I think an explicit example can be quite helpful.  If anything, more examples is always better for new users.

It also seems nice to have both examples tested.

---

Let me know if you want me to split addition of a test for the existing example into a separate commit.