### PR TITLE
atDepth: Add documentation example and a test for it

### DIFF
--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Select/Combinators.hs
@@ -50,8 +50,34 @@ infixl 6 @=~
 -- | The 'atDepth' operator constrains a 'Selector' to only match when it is at
 -- @depth@ below the previous selector.
 --
--- For example, @"div" // "a" `atDepth` 1@ creates a 'Selector' that matches
--- anchor tags that are direct children of a div tag.
+-- Note that @(\`atDepth` 1)@ is a very useful tool, as it allows you to match
+-- direct children of a tag. For this HTML:
+--
+-- @
+--   \<div\>
+--     Text before.
+--     \<a href="uri"\>link1\</a\>
+--     Text after.
+--     \<div\>
+--       Nested paragraph.
+--       \<a href="uri"\>link in the nested paragraph\</a\>
+--     \</div\>
+--     \<a href="uri"\>link2\</a\>
+--   \</div>
+-- @
+--
+-- Matching of all anchor tags that are direct children of the @div@ tag, can be
+-- done with this scraper:
+--
+-- @
+-- texts $ "div" '//' "a" '`atDepth`' 1
+-- @
+--
+-- Evaluating to:
+--
+-- @
+-- ["link1", "link2"]
+-- @
 atDepth :: Selector -> Int -> Selector
 atDepth (MkSelector xs) depth = MkSelector (addDepth xs)
   where addDepth []                 = []

--- a/scalpel-core/tests/TestMain.hs
+++ b/scalpel-core/tests/TestMain.hs
@@ -412,6 +412,23 @@ scrapeTests = "scrapeTests" ~: TestList [
             (texts $ "b" // "d" `atDepth` 1)
 
     ,   scrapeTest
+            "Haddock example for atDepth"
+            (unlines [
+              "<div>"
+            , "  Text before."
+            , "  <a href=\"uri\">link1</a>"
+            , "  Text after."
+            , "  <div>"
+            , "    Nested paragraph."
+            , "    <a href=\"uri\">link in the nested paragraph</a>"
+            , "  </div>"
+            , "  <a href=\"uri\">link2</a>"
+            , "</div>"
+            ])
+            (Just ["link1", "link2"])
+            (texts $ "div" // "a" `atDepth` 1)
+
+    ,   scrapeTest
             "// should handle tags closed out of order"
             "<a><b><c><d>2</d></b></c></a>"
             (Just ["2"])


### PR DESCRIPTION
`atDepth` can be very useful, but without an example it is really easy to overlook.