### PR TITLE
inSerial.stepTag{Next,Back}: Step over open tags

### DIFF
--- a/scalpel-core/src/Text/HTML/Scalpel/Core.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Core.hs
@@ -21,6 +21,7 @@ module Text.HTML.Scalpel.Core (
 ,   textSelector
 -- ** Wildcards
 ,   anySelector
+,   anyTagSelector
 -- ** Tag combinators
 ,   (//)
 ,   atDepth
@@ -61,6 +62,8 @@ module Text.HTML.Scalpel.Core (
 -- ** Primitives
 ,   stepNext
 ,   stepBack
+,   stepTagNext
+,   stepTagBack
 ,   seekNext
 ,   seekBack
 ,   untilNext

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Select.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Select.hs
@@ -313,6 +313,10 @@ nodeMatches :: TagSoup.StringLike str
             -> MatchResult
 nodeMatches (SelectNode node preds, settings) info cur root =
     checkSettings settings cur root `andMatch` checkTag node preds info
+nodeMatches (SelectAnyTag preds   , settings) info cur root =
+    checkSettings settings cur root `andMatch`
+    boolMatch (TagSoup.isTagOpen $ infoTag info) `andMatch`
+    checkPreds preds (infoTag info)
 nodeMatches (SelectAny preds      , settings) info cur root =
     checkSettings settings cur root `andMatch` checkPreds preds (infoTag info)
 nodeMatches (SelectText           , settings) info cur root =

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Select/Types.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Select/Types.hs
@@ -14,6 +14,7 @@ module Text.HTML.Scalpel.Internal.Select.Types (
 ,   SelectNode (..)
 ,   tagSelector
 ,   anySelector
+,   anyTagSelector
 ,   textSelector
 ,   toSelectNode
 ,   SelectSettings (..)
@@ -82,6 +83,10 @@ tagSelector tag = MkSelector [
     (toSelectNode (TagString tag) [], defaultSelectSettings)
   ]
 
+-- | A selector which will match any tag open node.  For example '<p>'.
+anyTagSelector :: Selector
+anyTagSelector = MkSelector [(SelectAnyTag [], defaultSelectSettings)]
+
 -- | A selector which will match any node (including tags and bare text).
 anySelector :: Selector
 anySelector = MkSelector [(SelectAny [], defaultSelectSettings)]
@@ -94,6 +99,7 @@ instance IsString Selector where
   fromString = tagSelector
 
 data SelectNode = SelectNode !T.Text [AttributePredicate]
+                | SelectAnyTag [AttributePredicate]
                 | SelectAny [AttributePredicate]
                 | SelectText
 

--- a/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
+++ b/scalpel-core/src/Text/HTML/Scalpel/Internal/Serial.hs
@@ -13,6 +13,8 @@ module Text.HTML.Scalpel.Internal.Serial (
 ,   inSerial
 ,   stepBack
 ,   stepNext
+,   stepTagBack
+,   stepTagNext
 ,   seekBack
 ,   seekNext
 ,   untilBack
@@ -21,6 +23,7 @@ module Text.HTML.Scalpel.Internal.Serial (
 
 import Text.HTML.Scalpel.Internal.Scrape
 import Text.HTML.Scalpel.Internal.Select
+import Text.HTML.Scalpel.Internal.Select.Types
 
 import Control.Applicative
 import Control.Monad
@@ -205,14 +208,89 @@ stepWith moveList (MkScraper (ReaderT scraper)) = MkSerialScraper . StateT $
 
 -- | Move the cursor back one node and execute the given scraper on the new
 -- focused node.
+--
+-- This function will move to the previous sibling node that is either an open
+-- tag node or a text node.  In most cases, HTML documents will have text nodes
+-- in-between element nodes, just due to formatting.  You may want to use
+-- 'stepTagBack or 'seekBack, to make your parsing logic more robust.
 stepBack :: (TagSoup.StringLike str, Monad m) => ScraperT str m a -> SerialScraperT str m a
 stepBack = stepWith PointedList.previous
 
 -- | Move the cursor forward one node and execute the given scraper on the new
 -- focused node.
+--
+-- This function will move to the next sibling node that is either an open tag
+-- node or a text node.  In most cases, HTML documents will have text nodes
+-- in-between element nodes, just due to formatting.  You may want to use
+-- 'stepTagNext' or 'seekNext', to make your parsing logic more robust.
 stepNext :: (TagSoup.StringLike str, Monad m)
     => ScraperT str m a -> SerialScraperT str m a
 stepNext = stepWith PointedList.next
+
+-- | Moves zipper to the next opening tag in the direction specified by the
+-- @moveList@ function.
+moveToTagNode :: TagSoup.StringLike str
+              => (SpecZipper str -> Maybe (SpecZipper str))
+              -> SpecZipper str
+              -> Maybe (SpecZipper str)
+moveToTagNode moveList zipper = do
+  zipper' <- moveList zipper
+  focus <- PointedList._focus zipper'
+  if null (select anyTagSelector focus)
+     then moveToTagNode moveList zipper'
+     else return zipper'
+
+-- | Move the cursor back until it finds an one open tag node and execute the
+-- given scraper on the newly focused node.  This will skip any comment, text,
+-- or close tag nodes.
+--
+-- If you want to skip over other sibling tags and look for a particular tag you
+-- want 'seekBack'.
+--
+-- See 'stepTagNext' for an example.
+stepTagBack :: (TagSoup.StringLike str, Monad m)
+            => ScraperT str m a
+            -> SerialScraperT str m a
+stepTagBack = stepWith $ moveToTagNode PointedList.previous
+
+-- | Move the cursor forward until it finds an one open tag node and execute the
+-- given scraper on the newly focused node.  This will skip any comment, text,
+-- or close tag nodes.
+--
+-- If you want to skip over other sibling tags and look for a particular tag you
+-- want 'seekNext.
+--
+-- For example, given the following HTML:
+--
+-- @
+--  \<article\>
+--    \<h1\>Title\</h1\>
+--    \<p\>Paragraph 1\</p\>
+--    \<!-- Comment --\>
+--    \<p\>Paragraph 2\</p\>
+--  \</article\>
+-- @
+--
+-- If the document logic expects exactly two paragraphs, it can be parsed like
+-- this:
+--
+-- @
+-- 'chroot' "article" $ 'inSerial' $ do
+--    title <- 'stepTagNext' $ text "h1"
+--    p1 <- 'stepTagNext' $ text "p"
+--    p2 <- 'stepTagNext' $ text "p"
+--    return (title, p1, p2))
+-- @
+--
+-- Evaluating to:
+--
+-- @
+--  (\"Title", "Paragraph 1", "Paragraph 2")
+-- @
+stepTagNext :: (TagSoup.StringLike str, Monad m)
+            => ScraperT str m a
+            -> SerialScraperT str m a
+stepTagNext = stepWith $ moveToTagNode PointedList.next
 
 seekWith :: (TagSoup.StringLike str, Monad m)
          => (SpecZipper str -> Maybe (SpecZipper str))

--- a/scalpel-core/tests/TestMain.hs
+++ b/scalpel-core/tests/TestMain.hs
@@ -459,6 +459,18 @@ scrapeTests = "scrapeTests" ~: TestList [
             (texts $ anySelector `atDepth` 0)
 
     ,   scrapeTest
+            "anyTagSelector should skip text nodes"
+            "1<a>2</a>3<b>4<c>5</c>6</b>7"
+            (Just ["<a>2</a>", "<b>4<c>5</c>6</b>"])
+            (htmls $ anyTagSelector `atDepth` 0)
+
+    ,   scrapeTest
+            "anyTagSelector should skip nested text nodes"
+            "1<a>2</a>3<b>4<c>5</c>6</b>7"
+            (Just ["<a>2</a>", "<b>4<c>5</c>6</b>", "<c>5</c>"])
+            (htmls $ anyTagSelector)
+
+    ,   scrapeTest
             "atDepth should treat out of focus close tags as immediately closed"
             "<a><b><c><d>2</d></c></a></b>"
             (Just ["2"])
@@ -481,6 +493,22 @@ scrapeTests = "scrapeTests" ~: TestList [
               return (a, b))
 
     ,   scrapeTest
+            "Applicative sanity check for stepTagNext"
+            "<a>1</a> 2 <b>3</b> 4"
+            (Just ("1", "3"))
+            (inSerial $ (,) <$> stepTagNext (text "a")
+                            <*> stepTagNext (text "b"))
+
+    ,   scrapeTest
+            "Applicative sanity check for stepTagNext and stepTagBack"
+            "<a>1</a> 2 <b>3</b> 4 <c>5</c>"
+            (Just ("1", "3", "5", "3", "1"))
+            (inSerial $ (,,,,) <$> stepTagNext (text "a")
+                               <*> stepTagNext (text "b")
+                               <*> stepTagNext (text "c")
+                               <*> stepTagBack (text "b")
+                               <*> stepTagBack (text "a"))
+    ,   scrapeTest
             "stepping off the end of the list without reading should be allowed"
             "<a>1</a><b>2</b><a>3</a>"
             (Just ["1", "2", "3", "2" , "1"])
@@ -493,6 +521,18 @@ scrapeTests = "scrapeTests" ~: TestList [
               return [a, b, c, d, e])
 
     ,   scrapeTest
+            "stepping off the end of the list with stepTagNext without reading should be allowed"
+            "<a>1</a> 2 <b>3</b> 4 <a>5</a>"
+            (Just ["1", "3", "5", "3", "1"])
+            (inSerial $ do
+              a <- stepTagNext $ text anySelector
+              b <- stepTagNext $ text anySelector
+              c <- stepTagNext $ text anySelector
+              d <- stepTagBack $ text anySelector
+              e <- stepTagBack $ text anySelector
+              return [a, b, c, d, e])
+
+    ,   scrapeTest
             "stepping off the end of the list and reading should fail"
             "<a>1</a><b>2</b><a>3</a>"
             Nothing
@@ -500,6 +540,49 @@ scrapeTests = "scrapeTests" ~: TestList [
                               <*> stepNext (text anySelector)
                               <*> stepNext (text anySelector)
                               <*> stepNext (text anySelector))
+
+    ,   scrapeTest
+            "stepping off the end of the list with stepTagNext and reading should fail"
+            "<a>1</a> 2 <b>3</b> 4 <a>5</a>"
+            Nothing
+            (inSerial $ (,,,) <$> stepTagNext (text anySelector)
+                              <*> stepTagNext (text anySelector)
+                              <*> stepTagNext (text anySelector)
+                              <*> stepTagNext (text anySelector))
+
+    ,   scrapeTest
+            "stepTagNext extracts text and html"
+            "<a>1</a><b>2</b>"
+            (Just ("<a>1</a>", "2"))
+            (inSerial $ (,) <$> stepTagNext (html anySelector)
+                            <*> stepTagNext (text anySelector))
+
+    ,   scrapeTest
+            "stepTagNext skips over text nodes"
+            "<a>1</a> text inbetween <b>2</b>"
+            (Just ("<a>1</a>", "<b>2</b>"))
+            (inSerial $ (,) <$> stepTagNext (html anySelector)
+                            <*> stepTagNext (html anySelector))
+
+    ,   scrapeTest
+            "stepTagNext goes to the next sibling, skipping subtrees"
+            "<a>1</a> 2 <b>3 <c>4</c> 5</b> 6 <d>7</d>"
+            (Just ("1", "3 4 5", "7", "3 4 5", "1"))
+            (inSerial $ (,,,,) <$> stepTagNext (text "a")
+                               <*> stepTagNext (text "b")
+                               <*> stepTagNext (text "d")
+                               <*> stepTagBack (text "b")
+                               <*> stepTagBack (text "a"))
+
+    ,   scrapeTest
+            "stepTagNext goes to the next sibling, skipping subtrees"
+            "<a>1</a> 2 <b>3 <c>4</c> 5</b> 6 <d>7</d>"
+            Nothing
+            -- We rely on the previous test to make sure the first two steps
+            -- succeed on their own.
+            (inSerial $ (,,) <$> stepTagNext (text "a")
+                             <*> stepTagNext (text "b")
+                             <*> stepTagNext (text "c"))
 
     ,   scrapeTest
             "seeking should skip over nodes"
@@ -680,6 +763,27 @@ scrapeTests = "scrapeTests" ~: TestList [
                 title <- seekNext $ text "h1"
                 p1 <- seekNext $ text "p"
                 p2 <- seekNext $ text "p"
+                return (title, p1, p2))
+
+    ,   scrapeTest
+            "Haddock example for inSerial.stepTagNext"
+            (unlines [
+              "<article>"
+            , "  <h1>Title</h1>"
+            , "  <p>Paragraph 1</p>"
+            , "  <!-- Comment -->"
+            , "  <p>Paragraph 2</p>"
+            , "</article>"
+            ])
+            (Just (
+                "Title"
+              , "Paragraph 1"
+              , "Paragraph 2"
+            ))
+            (chroot "article" $ inSerial $ do
+                title <- seekNext $ text "h1"
+                p1 <- stepTagNext $ text "p"
+                p2 <- stepTagNext $ text "p"
                 return (title, p1, p2))
     ]
 


### PR DESCRIPTION
As most HTML will contain formatting, there are text nodes in-between tag nodes, making `stepNext` and `stepBack` impractical for such HTML documents.

`seekNext` and `seekBack`, on the other hand, can skip over expected nodes, especially if the HTML structure is not exactly matching the scraper author intent.  As a result parse may succeed when it should not have, producing an expected result.